### PR TITLE
Use Time::HiRes and guard method call

### DIFF
--- a/Plugins/SpotOn/ProtocolHandler.pm
+++ b/Plugins/SpotOn/ProtocolHandler.pm
@@ -12,6 +12,7 @@ use Slim::Utils::Versions;
 use Slim::Utils::Cache;
 use Slim::Utils::Network;
 use Digest::MD5 qw(md5_hex);
+use Time::HiRes;
 
 my $log   = logger('plugin.spoton');
 my $prefs = preferences('plugin.spoton');
@@ -957,7 +958,10 @@ sub _asyncRefetch {
         # Notify LMS to refresh NowPlaying display
         if ($client) {
             require Slim::Control::Request;
-            $client->currentPlaylistUpdateTime(Time::HiRes::time());
+
+            $client->currentPlaylistUpdateTime(Time::HiRes::time())
+                if $client->can('currentPlaylistUpdateTime');
+
             Slim::Control::Request::notifyFromArray($client, ['newmetadata']);
         }
     };


### PR DESCRIPTION
Import Time::HiRes and use Time::HiRes::time() when updating the client's currentPlaylistUpdateTime. Add a guard (if $client->can('currentPlaylistUpdateTime')) to avoid calling the method on clients that don't implement it, preventing potential runtime errors. The subsequent notifyFromArray('newmetadata') behavior is unchanged.