### PR TITLE
Canonicalize SpotOn URLs and apply runtime metadata

### DIFF
--- a/Plugins/SpotOn/Connect.pm
+++ b/Plugins/SpotOn/Connect.pm
@@ -1021,13 +1021,26 @@ sub _fetchTrackMetadata {
         my $album    = ($trackInfo->{album} || {})->{name} || '';
         my $duration = ($trackInfo->{duration_ms} || 0) / 1000;
         my $cover    = _largestImage(($trackInfo->{album} || {})->{images}) || IMG_TRACK;
+        my $logicalUrl = ($song->track && $song->track->url)
+            ? $song->track->url
+            : $song->streamUrl;
+        my $streamUrl = $song->streamUrl;
+        my $displayTitle = "$artist - $title";
 
         # Instant display update
+        require Slim::Music::Info;
         Slim::Music::Info::setCurrentTitle(
-            $song->streamUrl,
-            "$artist - $title",
+            $logicalUrl,
+            $displayTitle,
             $client
         );
+        if ($streamUrl && $streamUrl ne $logicalUrl) {
+            Slim::Music::Info::setCurrentTitle(
+                $streamUrl,
+                $displayTitle,
+                $client
+            );
+        }
 
         # Full metadata for Now Playing display
         require Plugins::SpotOn::Plugin;
@@ -1039,7 +1052,8 @@ sub _fetchTrackMetadata {
             album        => $album,
             duration     => $duration,
             cover        => $cover,
-            url          => $song->streamUrl,
+            icon         => $cover,
+            url          => $logicalUrl,
             bitrate      => $bitrate . 'k',
             originalType => $type_str,
             type         => $type_str,

--- a/Plugins/SpotOn/Plugin.pm
+++ b/Plugins/SpotOn/Plugin.pm
@@ -1021,6 +1021,9 @@ sub _trackItem {
 
     my %item = (
         name          => "$title \x{2014} $artist",    # em-dash fallback for older clients
+        title         => $title,
+        artist        => $artist,
+        album         => $album,
         line1         => $title,
         line2         => $artist . ($album ? " \x{2022} $album" : ''),
         url           => $spoton_url,
@@ -1777,7 +1780,7 @@ sub _episodeItem {
     $cache->set('spoton_meta_' . md5_hex($spoton_url), {
         title    => $title,
         artist   => $showName,
-        album    => '',
+        album    => $showName,
         duration => $duration,
         cover    => $image,
         icon     => $image,
@@ -1789,6 +1792,9 @@ sub _episodeItem {
 
     my %item = (
         name          => $title . $explicit_tag,
+        title         => $title,
+        artist        => $showName,
+        album         => $showName,
         line1         => $title . $explicit_tag,
         line2         => $line2,
         url           => $spoton_url,
@@ -2519,6 +2525,9 @@ sub _albumTrackItem {
 
     my %item = (
         name      => ($trackNum ? "$trackNum. " : '') . $title,
+        title     => $title,
+        artist    => $artists,
+        album     => $albumName || '',
         line1     => ($trackNum ? "$trackNum. " : '') . $title,
         line2     => $line2,
         url       => $spoton_url,

--- a/Plugins/SpotOn/ProtocolHandler.pm
+++ b/Plugins/SpotOn/ProtocolHandler.pm
@@ -24,6 +24,59 @@ my $CRLF  = "\x0d\x0a";
 # D-05: debounce — one in-flight re-fetch per URL
 our %_pendingRefetch;
 
+# Guard against recursive setCurrentTitle() -> getCurrentTitle() -> getMetadataFor()
+our $_applyingCurrentTitle = 0;
+
+sub _canonicalSpotOnUrl {
+    my ($url) = @_;
+    return '' unless defined $url && $url ne '';
+
+    # LMS sometimes passes spoton:track:ID while our cache uses spoton://track:ID.
+    if ($url =~ m{^spoton:(?!//)}) {
+        $url =~ s{^spoton:}{spoton://};
+        return $url;
+    }
+
+    # Defensive fallback: some LMS/direct-stream paths can expose the daemon URL.
+    # Metadata must remain keyed by the logical SpotOn URL.
+    if ($url =~ m{^https?://[^/]+:\d+/(track|episode)/([A-Za-z0-9]+)}) {
+        return "spoton://$1:$2";
+    }
+
+    return $url;
+}
+
+sub _displayTitleFromMeta {
+    my ($meta) = @_;
+    return '' unless $meta && ref $meta eq 'HASH';
+    return '' unless $meta->{title};
+    return $meta->{artist}
+        ? "$meta->{artist} - $meta->{title}"
+        : $meta->{title};
+}
+
+sub _applyRuntimeMetadata {
+    my ($client, $song, $logicalUrl, $meta) = @_;
+    return unless $meta && ref $meta eq 'HASH';
+    return unless $logicalUrl;
+
+    $meta->{url} ||= $logicalUrl;
+
+    if ($song) {
+        $song->pluginData(info => $meta) if $song->can('pluginData');
+        if ($meta->{duration} && !($song->duration && $song->duration > 0)) {
+            $song->duration($meta->{duration});
+        }
+    }
+
+    return unless $client && $meta->{title};
+    return if $_applyingCurrentTitle;
+
+    local $_applyingCurrentTitle = 1;
+    require Slim::Music::Info;
+    Slim::Music::Info::setCurrentTitle($logicalUrl, _displayTitleFromMeta($meta), $client);
+}
+
 # Track Connect URLs translated to Browse by getNextTrack
 my %_translatedConnectUrls;
 
@@ -764,10 +817,7 @@ sub getMetadataFor {
     }
 
     # Normalize: cache is keyed on spoton://track:ID but LMS may pass spoton:track:ID
-    my $canonical = $url;
-    if ($canonical && $canonical =~ m{^spoton:(?!//)}) {
-        $canonical =~ s{^spoton:}{spoton://};
-    }
+    my $canonical = _canonicalSpotOnUrl($url);
 
     my $meta = $cache->get('spoton_meta_' . md5_hex($canonical));
 
@@ -782,32 +832,27 @@ sub getMetadataFor {
         return _placeholderMeta($url);
     }
 
-    # Spotty pattern: propagate duration to $song object so LMS seek bar works.
-    # Guard: only set when not already set to >0 (prevents overwrite on repeated calls).
-    if ($song && $meta && $meta->{duration}
-        && !($song->duration && $song->duration > 0)) {
-        $song->duration($meta->{duration});
-    }
+    my %out = %$meta;
+    $out{url} ||= $canonical;
 
     if ($client) {
         require Plugins::SpotOn::Plugin;
-        return { %$meta,
-            type    => Plugins::SpotOn::Plugin->_typeString($client, 'Browse'),
-            bitrate => Plugins::SpotOn::Plugin->_bitrateForClient($client) . 'k',
-        };
+        $out{type}    ||= Plugins::SpotOn::Plugin->_typeString($client, 'Browse');
+        $out{bitrate} ||= Plugins::SpotOn::Plugin->_bitrateForClient($client) . 'k';
     }
 
-    return $meta;
+    # Spotty-compatible runtime metadata path:
+    # keep metadata attached to the current Song object and update LMS current_title.
+    _applyRuntimeMetadata($client, $song, $canonical, \%out);
+
+    return \%out;
 }
 
 sub getIcon {
     my ($class, $url) = @_;
 
     if ($url) {
-        my $canonical = $url;
-        if ($canonical =~ m{^spoton:(?!//)}) {
-            $canonical =~ s{^spoton:}{spoton://};
-        }
+        my $canonical = _canonicalSpotOnUrl($url);
         my $meta = $cache->get('spoton_meta_' . md5_hex($canonical));
         return $meta->{cover} if $meta && $meta->{cover} && $meta->{cover} ne '/html/images/cover.png';
     }
@@ -845,6 +890,9 @@ sub _buildExplodedEpisodeItem {
     my $url   = 'spoton://episode:' . $ep->{id};
     return {
         name     => $title,
+        title    => $title,
+        artist   => $show->{name} || '',
+        album    => $show->{name} || '',
         line1    => $title,
         line2    => $show->{name} || '',
         url      => $url,
@@ -880,7 +928,7 @@ sub _cacheExplodedEpisode {
     $cache->set('spoton_meta_' . md5_hex($epUrl), {
         title    => $ep->{name} || '',
         artist   => $show->{name} || '',
-        album    => '',
+        album    => $show->{name} || '',
         duration => ($ep->{duration_ms} || 0) / 1000,
         cover    => $cover,
         icon     => $cover,
@@ -916,6 +964,8 @@ sub _asyncRefetch {
     return if $_pendingRefetch{$url};
 
     # Extract track/episode ID from Browse URL or from cached connect entry's spotifyUri
+    $canonical = _canonicalSpotOnUrl($canonical || $url);
+
     my ($trackId, $episodeId);
     if ($canonical && $canonical =~ m{spoton://track:([A-Za-z0-9]+)}) {
         $trackId = $1;
@@ -995,6 +1045,13 @@ sub _asyncRefetch {
             : $canonical;
 
         $cache->set('spoton_meta_' . md5_hex($cacheUrl), \%new_meta, 604800);
+
+        $new_meta{url} ||= $cacheUrl;
+        my $refetchSong;
+        if ($client && $client->can('currentSongForUrl')) {
+            $refetchSong = $client->currentSongForUrl($cacheUrl);
+        }
+        _applyRuntimeMetadata($client, $refetchSong, $cacheUrl, \%new_meta);
 
         # Notify LMS to refresh NowPlaying display
         if ($client) {


### PR DESCRIPTION
Normalize SpotOn URLs and attach runtime metadata to the current Song and Now Playing display. Added helpers (_canonicalSpotOnUrl, _displayTitleFromMeta, _applyRuntimeMetadata) and a recursion guard for setCurrentTitle to avoid loops. _fetchTrackMetadata now sets both logical and stream display titles and includes icon/url fields; many Browse item builders now include title/artist/album for richer UI. getMetadataFor and _asyncRefetch were updated to canonicalize keys, populate type/bitrate for clients, persist url in cached metadata, and apply runtime metadata to the playing Song so LMS shows correct duration/title/icon.