### PR TITLE
feat: per-player streaming mode preference (GH #96)

### DIFF
--- a/Plugins/SpotOn/HTML/EN/plugins/SpotOn/settings/basic.html
+++ b/Plugins/SpotOn/HTML/EN/plugins/SpotOn/settings/basic.html
@@ -108,6 +108,13 @@
 		</select>
 	[% END %]
 
+	[% WRAPPER setting title="PLUGIN_SPOTON_STREAMING_MODE_GLOBAL" desc="PLUGIN_SPOTON_STREAMING_MODE_GLOBAL_DESC" %]
+		<select class="stdedit" name="pref_streamingMode" id="pref_streamingMode">
+			<option value="direct" [% IF globalStreamingMode == 'direct' %]selected[% END %]>[% 'PLUGIN_SPOTON_STREAMING_MODE_DIRECT' | string %]</option>
+			<option value="proxy"  [% IF globalStreamingMode == 'proxy'  %]selected[% END %]>[% 'PLUGIN_SPOTON_STREAMING_MODE_PROXY'  | string %]</option>
+		</select>
+	[% END %]
+
 	[% WRAPPER setting title="PLUGIN_SPOTON_NORMALIZATION" desc="PLUGIN_SPOTON_NORMALIZATION_DESC" %]
 		<input type="checkbox" class="stdedit" name="pref_normalization" id="pref_normalization"
 			value="1" [% IF prefs.pref_normalization %]checked[% END %]/>

--- a/Plugins/SpotOn/HTML/EN/plugins/SpotOn/settings/player.html
+++ b/Plugins/SpotOn/HTML/EN/plugins/SpotOn/settings/player.html
@@ -40,6 +40,14 @@
 		</select>
 	[% END %]
 
+	[% WRAPPER setting title="PLUGIN_SPOTON_STREAMING_MODE" desc="PLUGIN_SPOTON_STREAMING_MODE_DESC" %]
+		<select class="stdedit" name="pref_streamingMode" id="pref_streamingMode">
+			<option value="global" [% IF streamingMode == 'global' %]selected[% END %]>[% 'PLUGIN_SPOTON_STREAMING_MODE_USE_GLOBAL' | string %]</option>
+			<option value="direct" [% IF streamingMode == 'direct' %]selected[% END %]>[% 'PLUGIN_SPOTON_STREAMING_MODE_DIRECT' | string %]</option>
+			<option value="proxy"  [% IF streamingMode == 'proxy'  %]selected[% END %]>[% 'PLUGIN_SPOTON_STREAMING_MODE_PROXY'  | string %]</option>
+		</select>
+	[% END %]
+
 	[% WRAPPER setting title="PLUGIN_SPOTON_BITRATE_OVERRIDE" desc="PLUGIN_SPOTON_BITRATE_OVERRIDE_DESC" %]
 		<select class="stdedit" name="pref_bitrateOverride" id="pref_bitrateOverride">
 			<option value=""    [% IF bitrateOverride == '' %]selected[% END %]>[% 'PLUGIN_SPOTON_BITRATE_GLOBAL' | string %]</option>

--- a/Plugins/SpotOn/Plugin.pm
+++ b/Plugins/SpotOn/Plugin.pm
@@ -115,6 +115,7 @@ sub initPlugin {
         enableAutoplay       => 1,     # D-08: Autoplay toggle, default on (controls Connect autoplay + DSTM)
         cacheSchemaVersion   => 0,     # D-02: migration marker — triggers cache clear on version bump
         diagnosticMode       => 0,     # #3: diagnostic logging toggle, default off
+        streamingMode        => 'direct', # COMPAT-01: global streaming mode default (direct|proxy); per-player override lives in same-name client pref (GH #96)
     });
 
     # D-02: cacheSchemaVersion guard — log when cache namespace version was bumped

--- a/Plugins/SpotOn/ProtocolHandler.pm
+++ b/Plugins/SpotOn/ProtocolHandler.pm
@@ -98,6 +98,32 @@ sub canDirectStream {
 
     return 0 unless $client;
 
+    # COMPAT-02: per-player streamingMode=proxy (or per-player 'global' resolving
+    # to a global streamingMode=proxy default) forces LMS-relayed streaming for
+    # BOTH Browse and Connect (D-02) — one gate at the top covers both branches
+    # below, no duplication. D-03: this gate is orthogonal to sync-group gating,
+    # which already happens independently inside the Browse/Connect branches.
+    # D-05: this gate is orthogonal to codec/transcoding format selection.
+    # Known, accepted side effect (review finding): in proxy mode this gate
+    # returns before the translated-Connect-URL cleanup further down, so an entry
+    # can remain in %_translatedConnectUrls; if the user later switches back to
+    # direct, one stale entry causes a single harmless extra return 0 (the proxy
+    # path in new() absorbs it) — bounded and accepted, no mitigation needed.
+    {
+        my $gateClient = $client->can('master') ? $client->master : $client;
+        my $mode = $prefs->client($gateClient)->get('streamingMode') || 'global';
+        if ($mode eq 'global') {
+            # GH #96: per-player unset/global resolves against the global default
+            $mode = $prefs->get('streamingMode') || 'direct';
+        }
+        if ($mode eq 'proxy') {
+            main::INFOLOG && $log->is_info && $log->info(
+                "canDirectStream: 0 (streamingMode=proxy)"
+            );
+            return 0;
+        }
+    }
+
     # Browse URL: direct stream to unified daemon /track/{id}
     if ($url && $url =~ m{^spoton://(track|episode):([A-Za-z0-9]+)$}) {
         my $contentType = $1;
@@ -769,6 +795,17 @@ sub getMetadataFor {
         $canonical =~ s{^spoton:}{spoton://};
     }
 
+    # COMPAT-03: canonicalize daemon HTTP URLs (direct-stream or proxy path) to
+    # the same spoton://{type}:{id} cache key used by Browse. D-07: only
+    # /track/{ID} and /episode/{ID} — /stream (Connect) has no track ID and is
+    # served via pluginData('info'), not this cache. Must tolerate a trailing
+    # ?start_position=N (seek offset, appended by canDirectStreamSong and the
+    # new() sync-group proxy path) — without the optional group, canonicalization
+    # silently fails on every seeked playback.
+    if ($canonical && $canonical =~ m{^https?://[^/]+/(track|episode)/([A-Za-z0-9]+)(?:\?.*)?$}) {
+        $canonical = "spoton://$1:$2";
+    }
+
     my $meta = $cache->get('spoton_meta_' . md5_hex($canonical));
 
     # Fallback: try original URL if normalization didn't help
@@ -807,6 +844,11 @@ sub getIcon {
         my $canonical = $url;
         if ($canonical =~ m{^spoton:(?!//)}) {
             $canonical =~ s{^spoton:}{spoton://};
+        }
+        # COMPAT-03: same HTTP-to-spoton canonicalization as getMetadataFor(), so
+        # icon lookups for daemon HTTP URLs hit the same cache entry.
+        if ($canonical =~ m{^https?://[^/]+/(track|episode)/([A-Za-z0-9]+)(?:\?.*)?$}) {
+            $canonical = "spoton://$1:$2";
         }
         my $meta = $cache->get('spoton_meta_' . md5_hex($canonical));
         return $meta->{cover} if $meta && $meta->{cover} && $meta->{cover} ne '/html/images/cover.png';

--- a/Plugins/SpotOn/Settings.pm
+++ b/Plugins/SpotOn/Settings.pm
@@ -175,6 +175,16 @@ sub handler {
         # Save diagnosticMode (global pref, not per-player) (#3)
         my $diagMode = $paramRef->{'pref_diagnosticMode'} ? 1 : 0;
         $prefs->set('diagnosticMode', $diagMode);
+
+        # Save global streamingMode default (COMPAT-01, GH #96 scope extension).
+        # Deliberately NOT in the prefs() return list (see comment there) — validated
+        # here and written directly so the base class handler cannot overwrite it
+        # with unsanitized raw form input.
+        if (defined $paramRef->{'pref_streamingMode'}) {
+            my $mode = $paramRef->{'pref_streamingMode'};
+            $mode = 'direct' unless $mode =~ /^(?:direct|proxy)$/;
+            $prefs->set('streamingMode', $mode);
+        }
     }
 
     # Auto-setup fallback for GET requests (manual reload, first visit).
@@ -200,6 +210,9 @@ sub handler {
 
     # Diagnostic mode status for template (#3)
     $paramRef->{diagnosticEnabled} = $prefs->get('diagnosticMode') ? 1 : 0;
+
+    # Global streaming mode default status for template (COMPAT-01, GH #96 scope extension)
+    $paramRef->{globalStreamingMode} = $prefs->get('streamingMode') || 'direct';
 
     my $logTotal = 0;
     my $spotonDir = catdir($serverPrefs->get('cachedir'), 'spoton');

--- a/Plugins/SpotOn/Settings/Player.pm
+++ b/Plugins/SpotOn/Settings/Player.pm
@@ -47,6 +47,12 @@ sub handler {
             $prefs->client($client)->set('streamFormat', $fmt);
         }
 
+        if (defined $paramRef->{'pref_streamingMode'}) {
+            my $mode = $paramRef->{'pref_streamingMode'};
+            $mode = 'global' unless $mode =~ /^(?:global|direct|proxy)$/;
+            $prefs->client($client)->set('streamingMode', $mode);
+        }
+
         if (defined $paramRef->{'pref_bitrateOverride'}) {
             my $override = $paramRef->{'pref_bitrateOverride'} // '';
             $override = '' unless $override =~ /^(?:96|160|320)$/;
@@ -81,6 +87,8 @@ sub handler {
         $paramRef->{streamFormat} = $prefs->client($client)->get('streamFormat')
                                  || $prefs->client($client)->get('connectOggOverride')
                                  || 'auto';
+        # COMPAT-01: no legacy-pref fallback chain (D-05 — streamingMode has no predecessor pref)
+        $paramRef->{streamingMode} = $prefs->client($client)->get('streamingMode') || 'global';
         require Plugins::SpotOn::Helper;
         $paramRef->{canAutoplay}     = Plugins::SpotOn::Helper->getCapability('autoplay') ? 1 : 0;
         my $rawAutoplay = $prefs->client($client)->get('enableAutoplay');

--- a/Plugins/SpotOn/strings.txt
+++ b/Plugins/SpotOn/strings.txt
@@ -1051,6 +1051,97 @@ PLUGIN_SPOTON_STREAM_FORMAT_MP3
 	PL	MP3 (transkodowane)
 	SV	MP3 (transkodad)
 
+PLUGIN_SPOTON_STREAMING_MODE
+	CS	Režim streamování
+	DA	Streamingtilstand
+	DE	Streaming-Modus
+	EN	Streaming Mode
+	ES	Modo de streaming
+	FR	Mode de diffusion
+	IT	Modalità di streaming
+	NL	Streamingmodus
+	NO	Strømmemodus
+	PL	Tryb strumieniowania
+	SV	Streamingläge
+
+PLUGIN_SPOTON_STREAMING_MODE_DESC
+	CS	Globální používá výchozí nastavení serveru. Přímý streamuje přímo z démona SpotOn. Proxy nechá LMS přenášet stream, vhodné pro přehrávače, které přijímají metadata ve streamu (např. UPnP/DLNA přehrávače přes UPnPBridge). Pokud si nejste jisti, ponechte na Globální.
+	DA	Global bruger serverens standardindstilling. Direkte streamer direkte fra SpotOn-dæmonen. Proxy lader LMS videresende streamen, til afspillere der modtager metadata i streamen (f.eks. UPnP/DLNA-afspillere via UPnPBridge). Hvis du er i tvivl, så behold Global.
+	DE	Global verwendet die Server-Standardeinstellung. Direkt streamt direkt vom SpotOn-Daemon. Proxy lässt LMS den Stream weiterleiten, für Player, die Metadaten im Stream empfangen (z.B. UPnP/DLNA-Player über UPnPBridge). Im Zweifel bei Global belassen.
+	EN	Global uses the server default. Direct streams straight from the SpotOn daemon. Proxy makes LMS relay the stream, for players that receive metadata in the stream (e.g. UPnP/DLNA players via UPnPBridge). If unsure, leave on Global.
+	ES	Global usa el valor predeterminado del servidor. Directo transmite directamente desde el daemon de SpotOn. Proxy hace que LMS retransmita el flujo, para reproductores que reciben metadatos en el flujo (p. ej. reproductores UPnP/DLNA vía UPnPBridge). Si no está seguro, deje Global.
+	FR	Global utilise la valeur par défaut du serveur. Direct diffuse directement depuis le démon SpotOn. Proxy fait relayer le flux par LMS, pour les lecteurs qui reçoivent les métadonnées dans le flux (ex. lecteurs UPnP/DLNA via UPnPBridge). En cas de doute, laissez sur Global.
+	IT	Globale usa il valore predefinito del server. Diretto trasmette direttamente dal demone SpotOn. Proxy fa sì che LMS inoltri lo stream, per i lettori che ricevono i metadati nello stream (es. lettori UPnP/DLNA tramite UPnPBridge). In caso di dubbio, lasciare su Globale.
+	NL	Globaal gebruikt de standaardinstelling van de server. Direct streamt rechtstreeks vanaf de SpotOn-daemon. Proxy laat LMS de stream doorgeven, voor spelers die metadata in de stream ontvangen (bijv. UPnP/DLNA-spelers via UPnPBridge). Bij twijfel op Globaal laten.
+	NO	Global bruker serverens standardinnstilling. Direkte strømmer rett fra SpotOn-daemonen. Proxy lar LMS videresende strømmen, for spillere som mottar metadata i strømmen (f.eks. UPnP/DLNA-spillere via UPnPBridge). Hvis du er usikker, behold Global.
+	PL	Globalny używa domyślnego ustawienia serwera. Bezpośredni strumieniuje bezpośrednio z demona SpotOn. Proxy powoduje, że LMS przekazuje strumień, dla odtwarzaczy odbierających metadane w strumieniu (np. odtwarzacze UPnP/DLNA przez UPnPBridge). W razie wątpliwości pozostaw Globalny.
+	SV	Global använder serverns standardvärde. Direkt strömmar direkt från SpotOn-demonen. Proxy låter LMS vidarebefordra strömmen, för spelare som tar emot metadata i strömmen (t.ex. UPnP/DLNA-spelare via UPnPBridge). Vid osäkerhet, behåll Global.
+
+PLUGIN_SPOTON_STREAMING_MODE_DIRECT
+	CS	Přímý
+	DA	Direkte
+	DE	Direkt
+	EN	Direct
+	ES	Directo
+	FR	Direct
+	IT	Diretto
+	NL	Direct
+	NO	Direkte
+	PL	Bezpośredni
+	SV	Direkt
+
+PLUGIN_SPOTON_STREAMING_MODE_PROXY
+	CS	Proxy
+	DA	Proxy
+	DE	Proxy
+	EN	Proxy
+	ES	Proxy
+	FR	Proxy
+	IT	Proxy
+	NL	Proxy
+	NO	Proxy
+	PL	Proxy
+	SV	Proxy
+
+PLUGIN_SPOTON_STREAMING_MODE_USE_GLOBAL
+	CS	Globální (výchozí)
+	DA	Global (standard)
+	DE	Global (Standard)
+	EN	Global (Default)
+	ES	Global (predeterminado)
+	FR	Global (par défaut)
+	IT	Globale (predefinito)
+	NL	Globaal (standaard)
+	NO	Global (standard)
+	PL	Globalny (domyślny)
+	SV	Global (standard)
+
+PLUGIN_SPOTON_STREAMING_MODE_GLOBAL
+	CS	Režim streamování (výchozí)
+	DA	Streamingtilstand (standard)
+	DE	Streaming-Modus (Standard)
+	EN	Streaming Mode (Default)
+	ES	Modo de streaming (predeterminado)
+	FR	Mode de diffusion (par défaut)
+	IT	Modalità di streaming (predefinita)
+	NL	Streamingmodus (standaard)
+	NO	Strømmemodus (standard)
+	PL	Tryb strumieniowania (domyślny)
+	SV	Streamingläge (standard)
+
+PLUGIN_SPOTON_STREAMING_MODE_GLOBAL_DESC
+	CS	Výchozí režim streamování pro všechny přehrávače; Přímý = přehrávače streamují přímo z démona SpotOn (nejnižší zátěž); Proxy = LMS přenáší stream (potřebné pro některé přehrávače, např. UPnP/DLNA přes UPnPBridge, pro zobrazení metadat); jednotlivé přehrávače mohou toto nastavení přepsat v Nastavení přehrávače.
+	DA	Standard streamingtilstand for alle afspillere; Direkte = afspillere streamer direkte fra SpotOn-dæmonen (laveste overhead); Proxy = LMS videresender streamen (nødvendigt for nogle afspillere, f.eks. UPnP/DLNA via UPnPBridge, for at vise metadata); individuelle afspillere kan tilsidesætte dette i Afspillerindstillinger.
+	DE	Standard-Streaming-Modus für alle Player; Direkt = Player streamen direkt vom SpotOn-Daemon (geringster Overhead); Proxy = LMS leitet den Stream weiter (für manche Player nötig, z.B. UPnP/DLNA über UPnPBridge, um Metadaten anzuzeigen); einzelne Player können dies in den Player-Einstellungen überschreiben.
+	EN	Default streaming mode for all players; Direct = players stream straight from the SpotOn daemon (lowest overhead); Proxy = LMS relays the stream (needed by some players, e.g. UPnP/DLNA via UPnPBridge, to display metadata); individual players can override this in Player Settings.
+	ES	Modo de streaming predeterminado para todos los reproductores; Directo = los reproductores transmiten directamente desde el daemon de SpotOn (menor sobrecarga); Proxy = LMS retransmite el flujo (necesario para algunos reproductores, p. ej. UPnP/DLNA vía UPnPBridge, para mostrar metadatos); los reproductores individuales pueden anular esto en Configuración del reproductor.
+	FR	Mode de diffusion par défaut pour tous les lecteurs ; Direct = les lecteurs diffusent directement depuis le démon SpotOn (charge la plus faible) ; Proxy = LMS relaie le flux (nécessaire pour certains lecteurs, ex. UPnP/DLNA via UPnPBridge, pour afficher les métadonnées) ; chaque lecteur peut remplacer ce réglage dans les paramètres du lecteur.
+	IT	Modalità di streaming predefinita per tutti i lettori; Diretto = i lettori trasmettono direttamente dal demone SpotOn (overhead minimo); Proxy = LMS inoltra lo stream (necessario per alcuni lettori, es. UPnP/DLNA tramite UPnPBridge, per mostrare i metadati); i singoli lettori possono sovrascrivere questa impostazione nelle Impostazioni del lettore.
+	NL	Standaard streamingmodus voor alle spelers; Direct = spelers streamen rechtstreeks vanaf de SpotOn-daemon (laagste overhead); Proxy = LMS geeft de stream door (nodig voor sommige spelers, bijv. UPnP/DLNA via UPnPBridge, om metadata te tonen); individuele spelers kunnen dit overschrijven in Spelerinstellingen.
+	NO	Standard strømmemodus for alle spillere; Direkte = spillere strømmer rett fra SpotOn-daemonen (lavest overhead); Proxy = LMS videresender strømmen (nødvendig for enkelte spillere, f.eks. UPnP/DLNA via UPnPBridge, for å vise metadata); individuelle spillere kan overstyre dette i Spillerinnstillinger.
+	PL	Domyślny tryb strumieniowania dla wszystkich odtwarzaczy; Bezpośredni = odtwarzacze strumieniują bezpośrednio z demona SpotOn (najniższe obciążenie); Proxy = LMS przekazuje strumień (potrzebne dla niektórych odtwarzaczy, np. UPnP/DLNA przez UPnPBridge, do wyświetlania metadanych); poszczególne odtwarzacze mogą to nadpisać w Ustawieniach odtwarzacza.
+	SV	Standard streamingläge för alla spelare; Direkt = spelare strömmar direkt från SpotOn-demonen (lägst overhead); Proxy = LMS vidarebefordrar strömmen (behövs för vissa spelare, t.ex. UPnP/DLNA via UPnPBridge, för att visa metadata); enskilda spelare kan åsidosätta detta i Spelarinställningar.
+
 PLUGIN_SPOTON_BITRATE_OVERRIDE
 	CS	Přenosová rychlost (přehrávač)
 	DA	Bithastighed (afspiller)

--- a/t/09_settings.t
+++ b/t/09_settings.t
@@ -430,6 +430,49 @@ SKIP: {
 }
 
 # ============================================================
+# COMPAT-01: Global streamingMode handler save/validation (GH #96 scope
+# extension) — real handler-execution coverage of the global setting.
+# ============================================================
+SKIP: {
+    skip "Settings.pm not yet updated with global streamingMode handler", 3
+        unless -f $settings_module && do {
+            open(my $fh, '<', $settings_module) or die $!;
+            my $src = do { local $/; <$fh> };
+            close($fh);
+            $src =~ /pref_streamingMode/;
+        };
+
+    skip "Settings.pm module required for global streamingMode test", 3
+        unless eval { require Plugins::SpotOn::Settings; 1 };
+
+    my $prefs = Slim::Utils::Prefs::preferences('plugin.spoton');
+
+    Plugins::SpotOn::Settings->handler(
+        undef, { saveSettings => 1, pref_streamingMode => 'proxy' },
+        sub { }, undef, undef
+    );
+    is($prefs->get('streamingMode'), 'proxy',
+        'COMPAT-01: global streamingMode handler persists valid "proxy" value');
+
+    Plugins::SpotOn::Settings->handler(
+        undef, { saveSettings => 1, pref_streamingMode => 'bogus' },
+        sub { }, undef, undef
+    );
+    is($prefs->get('streamingMode'), 'direct',
+        'COMPAT-01: global streamingMode handler falls back to "direct" for invalid value');
+
+    # Set a known sentinel value directly, then verify a saveSettings call with
+    # no pref_streamingMode key leaves it untouched (defined-check guard, T-47-05).
+    $prefs->set('streamingMode', 'proxy');
+    Plugins::SpotOn::Settings->handler(
+        undef, { saveSettings => 1 },
+        sub { }, undef, undef
+    );
+    is($prefs->get('streamingMode'), 'proxy',
+        'COMPAT-01: global streamingMode handler leaves value untouched when pref_streamingMode key absent');
+}
+
+# ============================================================
 # discoveryRunning template param test
 # ============================================================
 SKIP: {

--- a/t/11_track_history.t
+++ b/t/11_track_history.t
@@ -642,4 +642,109 @@ subtest 'Connect URL returns Browse mode label not Connect' => sub {
     }
 };
 
+# ============================================================
+# Test K: COMPAT-03 — HTTP track URL canonicalizes to spoton://track:ID cache key
+# ============================================================
+subtest 'COMPAT-03: HTTP track URL canonicalizes to spoton:// cache key' => sub {
+    use Digest::MD5 qw(md5_hex);
+
+    my $browse_url = 'spoton://track:ABC123';
+    my $cache_key  = 'spoton_meta_' . md5_hex($browse_url);
+
+    Slim::Utils::Cache->new->clear();
+    Slim::Utils::Cache->new->set($cache_key, {
+        title    => 'HTTP Canon Track',
+        artist   => 'HTTP Canon Artist',
+        album    => 'HTTP Canon Album',
+        duration => 200,
+        cover    => 'https://example.com/httpcanon.jpg',
+        icon     => 'https://example.com/httpcanon.jpg',
+        bitrate  => '320k',
+        type     => 'OGG (Spotify Browse)',
+    }, 604800);
+
+    my $client   = MockClient->new('player_http_canon');
+    my $http_url = 'http://127.0.0.1:39755/track/ABC123';
+    my $result   = Plugins::SpotOn::ProtocolHandler->getMetadataFor($client, $http_url);
+
+    ok(defined $result, 'COMPAT-03: getMetadataFor returns defined result for daemon HTTP track URL');
+    is($result->{title}, 'HTTP Canon Track',
+        'COMPAT-03: daemon HTTP /track/{ID} URL hits the cache entry keyed under spoton://track:{ID}');
+};
+
+# ============================================================
+# Test L: COMPAT-03 — query-string tolerance (?start_position=N, Pitfall 2)
+# ============================================================
+subtest 'COMPAT-03: HTTP track URL with ?start_position= still hits cache' => sub {
+    use Digest::MD5 qw(md5_hex);
+
+    my $browse_url = 'spoton://track:ABC123';
+    my $cache_key  = 'spoton_meta_' . md5_hex($browse_url);
+
+    Slim::Utils::Cache->new->clear();
+    Slim::Utils::Cache->new->set($cache_key, {
+        title    => 'Seek Canon Track',
+        artist   => 'Seek Canon Artist',
+        album    => 'Seek Canon Album',
+        duration => 200,
+        cover    => 'https://example.com/seekcanon.jpg',
+        icon     => 'https://example.com/seekcanon.jpg',
+        bitrate  => '320k',
+        type     => 'OGG (Spotify Browse)',
+    }, 604800);
+
+    my $client   = MockClient->new('player_seek_canon');
+    my $http_url = 'http://127.0.0.1:39755/track/ABC123?start_position=30';
+    my $result   = Plugins::SpotOn::ProtocolHandler->getMetadataFor($client, $http_url);
+
+    ok(defined $result, 'COMPAT-03: getMetadataFor returns defined result with seek query string');
+    is($result->{title}, 'Seek Canon Track',
+        'COMPAT-03 Pitfall 2: ?start_position=N suffix does not break canonicalization');
+};
+
+# ============================================================
+# Test M: COMPAT-03 — episode canonicalization
+# ============================================================
+subtest 'COMPAT-03: HTTP episode URL canonicalizes to spoton://episode:ID cache key' => sub {
+    use Digest::MD5 qw(md5_hex);
+
+    my $browse_url = 'spoton://episode:XYZ789';
+    my $cache_key  = 'spoton_meta_' . md5_hex($browse_url);
+
+    Slim::Utils::Cache->new->clear();
+    Slim::Utils::Cache->new->set($cache_key, {
+        title    => 'Episode Canon',
+        artist   => 'Podcast',
+        album    => '',
+        duration => 1800,
+        cover    => 'https://example.com/epcanon.jpg',
+        icon     => 'https://example.com/epcanon.jpg',
+        bitrate  => '320k',
+        type     => 'OGG (Spotify Browse)',
+    }, 604800);
+
+    my $client   = MockClient->new('player_episode_canon');
+    my $http_url = 'http://127.0.0.1:39755/episode/XYZ789';
+    my $result   = Plugins::SpotOn::ProtocolHandler->getMetadataFor($client, $http_url);
+
+    ok(defined $result, 'COMPAT-03: getMetadataFor returns defined result for daemon HTTP episode URL');
+    is($result->{title}, 'Episode Canon',
+        'COMPAT-03: daemon HTTP /episode/{ID} URL hits the cache entry keyed under spoton://episode:{ID}');
+};
+
+# ============================================================
+# Test N: D-07 — /stream URLs are NOT canonicalized (no track ID to derive a key from)
+# ============================================================
+subtest 'D-07: HTTP /stream URL is not canonicalized, returns placeholder' => sub {
+    Slim::Utils::Cache->new->clear();
+
+    my $client   = MockClient->new('player_stream_excl');
+    my $http_url = 'http://127.0.0.1:39755/stream';
+    my $result   = Plugins::SpotOn::ProtocolHandler->getMetadataFor($client, $http_url);
+
+    ok(defined $result, 'D-07: /stream URL returns defined result');
+    is($result->{cover}, '/html/images/cover.png',
+        'D-07: /stream URL is not canonicalized to a track cache key — falls to placeholder');
+};
+
 done_testing();

--- a/t/15_streaming_mode.t
+++ b/t/15_streaming_mode.t
@@ -1,0 +1,542 @@
+#!/usr/bin/perl
+use strict;
+use warnings;
+use Test::More;
+use File::Basename qw(dirname);
+use File::Temp qw(tempdir);
+use File::Path qw(make_path);
+use Cwd qw(abs_path);
+
+# Resolve project root
+my $test_dir    = dirname(abs_path($0));
+my $project_dir = dirname($test_dir);
+
+# Create temporary directories for LMS stubs and cache
+my $stub_dir  = tempdir(CLEANUP => 1);
+my $cache_dir = tempdir(CLEANUP => 1);
+
+# ============================================================
+# Helper: write a stub Perl module
+# ============================================================
+sub write_stub {
+    my ($dir, $pkg, $code) = @_;
+    my @parts = split /::/, $pkg;
+    my $file  = pop @parts;
+    my $path  = $dir . '/' . join('/', @parts);
+    make_path($path) unless -d $path;
+    open(my $fh, '>', "$path/$file.pm") or die "Cannot write stub $pkg: $!";
+    print $fh $code;
+    close($fh);
+}
+
+# ============================================================
+# LMS Module Stubs (copied from t/11_track_history.t — the canonical
+# analog for loading ProtocolHandler.pm with a complete stub set)
+# ============================================================
+
+# Stub: Log::Log4perl::Logger
+write_stub($stub_dir, 'Log::Log4perl::Logger', <<'END');
+package Log::Log4perl::Logger;
+sub new     { bless {}, shift }
+sub AUTOLOAD { }
+sub can     { 1 }
+1;
+END
+
+# Stub: Log::Log4perl
+write_stub($stub_dir, 'Log::Log4perl', <<'END');
+package Log::Log4perl;
+sub get_logger { return bless {}, 'Log::Log4perl::Logger' }
+sub init { }
+1;
+END
+
+# Stub: Slim::Utils::Log
+write_stub($stub_dir, 'Slim::Utils::Log', <<'END');
+package Slim::Utils::Log;
+use parent 'Exporter';
+our @EXPORT_OK = qw(logger addLogCategory);
+my $_noop_logger = bless {}, 'Slim::Utils::Log';
+
+sub addLogCategory { return $_noop_logger }
+sub logger         { return $_noop_logger }
+sub info  { }
+sub warn  { }
+sub error { }
+sub debug { }
+sub is_info  { 0 }
+sub is_debug { 0 }
+sub AUTOLOAD { }
+sub can { 1 }
+
+sub import {
+    my $class = shift;
+    my $caller = caller;
+    no strict 'refs';
+    *{"${caller}::logger"}         = \&logger;
+    *{"${caller}::addLogCategory"} = \&addLogCategory;
+}
+1;
+END
+
+# Stub: Slim::Utils::Prefs (with client() support for per-player prefs)
+my $prefs_cache_dir = $cache_dir;
+write_stub($stub_dir, 'Slim::Utils::Prefs', <<"END");
+package Slim::Utils::Prefs;
+use parent 'Exporter';
+our \@EXPORT_OK = qw(preferences);
+my %_store;
+my %_ns_store = ( server => { cachedir => '$prefs_cache_dir' } );
+
+sub import {
+    my \$class = shift;
+    my \$caller = caller;
+    no strict 'refs';
+    *{"\${caller}::preferences"} = \\&preferences;
+}
+
+sub preferences {
+    my \$ns = \$_[0] eq 'Slim::Utils::Prefs' ? \$_[1] : \$_[0];
+    return bless { _ns => \$ns }, 'Slim::Utils::Prefs';
+}
+
+sub init {
+    my (\$self, \$defaults) = \@_;
+    for my \$k (keys \%{\$defaults}) {
+        \$_store{ \$self->{_ns} }{\$k} //= \$defaults->{\$k};
+    }
+}
+
+sub get {
+    my (\$self, \$key) = \@_;
+    if (exists \$_ns_store{ \$self->{_ns} }) {
+        return \$_ns_store{ \$self->{_ns} }{\$key};
+    }
+    return \$_store{ \$self->{_ns} }{\$key};
+}
+
+sub set {
+    my (\$self, \$key, \$val) = \@_;
+    \$_store{ \$self->{_ns} }{\$key} = \$val;
+}
+
+sub client {
+    my (\$self, \$client) = \@_;
+    my \$client_id = ref \$client ? "\$client" : (\$client // 'default');
+    return bless { _ns => \$self->{_ns} . '_client_' . \$client_id }, 'Slim::Utils::Prefs';
+}
+
+sub setChange { }
+sub AUTOLOAD  { }
+1;
+END
+
+# Stub: Slim::Utils::Cache
+write_stub($stub_dir, 'Slim::Utils::Cache', <<'END');
+package Slim::Utils::Cache;
+my %_store;
+my %_ttl;
+sub new    { bless {}, shift }
+sub get    { $_store{$_[1]} }
+sub set    { $_store{$_[1]} = $_[2]; $_ttl{$_[1]} = $_[3]; 1 }
+sub remove { delete $_store{$_[1]}; delete $_ttl{$_[1]} }
+sub ttl    { $_ttl{$_[1]} }
+sub clear  { %_store = (); %_ttl = () }
+1;
+END
+
+# Stub: Slim::Utils::Timers
+write_stub($stub_dir, 'Slim::Utils::Timers', <<'END');
+package Slim::Utils::Timers;
+sub setTimer   { }
+sub killTimers { }
+1;
+END
+
+# Stub: Slim::Utils::Strings
+write_stub($stub_dir, 'Slim::Utils::Strings', <<'END');
+package Slim::Utils::Strings;
+use parent 'Exporter';
+our @EXPORT_OK = qw(string cstring);
+sub string  { join(' ', grep { defined } @_[1..$#_]) }
+sub cstring { join(' ', grep { defined } @_[1..$#_]) }
+1;
+END
+
+# Stub: Slim::Utils::Unicode
+write_stub($stub_dir, 'Slim::Utils::Unicode', <<'END');
+package Slim::Utils::Unicode;
+sub utf8toLatin1Transliterate { $_[1] }
+1;
+END
+
+# Stub: JSON::XS (Plugin.pm uses 'use JSON::XS qw(encode_json)')
+write_stub($stub_dir, 'JSON::XS', <<'END');
+package JSON::XS;
+use parent 'Exporter';
+our @EXPORT_OK = qw(encode_json decode_json);
+use JSON::PP ();
+sub encode_json { JSON::PP::encode_json($_[0]) }
+sub decode_json { JSON::PP::decode_json($_[0]) }
+1;
+END
+
+# Stub: JSON::XS::VersionOneAndTwo
+write_stub($stub_dir, 'JSON::XS::VersionOneAndTwo', <<'END');
+package JSON::XS::VersionOneAndTwo;
+use parent 'Exporter';
+our @EXPORT = qw(from_json to_json);
+use JSON::PP ();
+sub from_json { JSON::PP::decode_json($_[0]) }
+sub to_json   { JSON::PP::encode_json($_[0]) }
+1;
+END
+
+# Stub: Time::HiRes
+write_stub($stub_dir, 'Time::HiRes', <<'END');
+package Time::HiRes;
+use POSIX qw();
+sub time  { POSIX::floor(CORE::time()) + 0 }
+sub sleep { CORE::sleep($_[1]) }
+1;
+END
+
+# Stub: Slim::Plugin::OPMLBased
+write_stub($stub_dir, 'Slim::Plugin::OPMLBased', <<'END');
+package Slim::Plugin::OPMLBased;
+sub new        { bless {}, shift }
+sub initPlugin { }
+sub _pluginDataFor { }
+sub AUTOLOAD   { }
+sub can        { 1 }
+1;
+END
+
+# Stub: Slim::Player::ProtocolHandlers
+write_stub($stub_dir, 'Slim::Player::ProtocolHandlers', <<'END');
+package Slim::Player::ProtocolHandlers;
+sub registerHandler { }
+1;
+END
+
+# Stub: Slim::Player::TranscodingHelper
+write_stub($stub_dir, 'Slim::Player::TranscodingHelper', <<'END');
+package Slim::Player::TranscodingHelper;
+our %commandTable;
+sub getConvertCommand2 { return ('command', 'type', 'F', 'T', 0, 1) }
+sub Conversions { return \%commandTable }
+1;
+END
+
+# Stub: Slim::Formats::RemoteStream
+write_stub($stub_dir, 'Slim::Formats::RemoteStream', <<'END');
+package Slim::Formats::RemoteStream;
+sub new      { bless {}, shift }
+sub AUTOLOAD { }
+sub can      { 1 }
+1;
+END
+
+# Stub: Slim::Utils::Network (needed by ProtocolHandler.pm)
+write_stub($stub_dir, 'Slim::Utils::Network', <<'END');
+package Slim::Utils::Network;
+sub serverAddr { '127.0.0.1' }
+1;
+END
+
+# Stub: Slim::Utils::Versions (needed by ProtocolHandler.pm)
+write_stub($stub_dir, 'Slim::Utils::Versions', <<'END');
+package Slim::Utils::Versions;
+sub compareVersions { 0 }
+1;
+END
+
+# Stub: Slim::Utils::Misc (needed by ProtocolHandler.pm)
+write_stub($stub_dir, 'Slim::Utils::Misc', <<'END');
+package Slim::Utils::Misc;
+sub crackURL { ('127.0.0.1', 80, '/stream') }
+1;
+END
+
+# Stub: Slim::Control::Request
+write_stub($stub_dir, 'Slim::Control::Request', <<'END');
+package Slim::Control::Request;
+our $notify_count = 0;
+sub notifyFromArray { $notify_count++ }
+sub subscribe   { }
+sub unsubscribe { }
+sub addDispatch { }
+1;
+END
+
+# Stub: Slim::Music::Info
+write_stub($stub_dir, 'Slim::Music::Info', <<'END');
+package Slim::Music::Info;
+sub setCurrentTitle { }
+1;
+END
+
+# Stub: Slim::Player::Protocols::HTTP
+write_stub($stub_dir, 'Slim::Player::Protocols::HTTP', <<'END');
+package Slim::Player::Protocols::HTTP;
+sub new { bless {}, shift }
+sub AUTOLOAD { }
+sub can { 1 }
+1;
+END
+
+# Stub: Plugins::SpotOn::API::Client with controllable $mock_track
+write_stub($stub_dir, 'Plugins::SpotOn::API::Client', <<'END');
+package Plugins::SpotOn::API::Client;
+our $mock_track = undef;
+sub getTrack {
+    my ($class, $account_id, $track_id, $cb) = @_;
+    $cb->($mock_track);
+}
+sub AUTOLOAD { }
+1;
+END
+
+# Stub: Plugins::SpotOn::Helper with controllable getCapability
+write_stub($stub_dir, 'Plugins::SpotOn::Helper', <<'END');
+package Plugins::SpotOn::Helper;
+our $helperCapabilities = {};
+sub get { return '/usr/bin/false' }
+sub init { }
+sub getCapability {
+    my ($class, $key) = @_;
+    return $helperCapabilities->{$key} if $helperCapabilities && defined $helperCapabilities->{$key};
+    return undef;
+}
+1;
+END
+
+# Stub: URI::Escape — not Perl core, bundled by LMS
+write_stub($stub_dir, 'URI::Escape', <<'END');
+package URI::Escape;
+use Exporter 'import';
+our @EXPORT_OK = qw(uri_escape);
+sub uri_escape { my ($s) = @_; $s =~ s/([^A-Za-z0-9\-._~])/sprintf("%%%02X", ord($1))/ge; return $s; }
+1;
+END
+
+# Stub: Plugins::SpotOn::Unified::DaemonManager (COMPAT-02 — new for canDirectStream coverage)
+# helperForClient always returns a live mock helper on a fixed stream port so the
+# Browse/Connect branches in canDirectStream() construct a daemon HTTP URL.
+write_stub($stub_dir, 'Plugins::SpotOn::Unified::DaemonManager', <<'END');
+package Plugins::SpotOn::Unified::DaemonManager;
+sub helperForClient { return bless {}, 'MockDaemonHelper' }
+sub scheduleInit { }
+sub resolvePassthroughForClient { return 0 }
+
+package MockDaemonHelper;
+sub alive       { 1 }
+sub _streamPort { 39755 }
+1;
+END
+
+# ============================================================
+# main:: constants
+# ============================================================
+BEGIN {
+    no warnings 'redefine';
+    *main::TRANSCODING = sub () { 0 };
+    *main::WEBUI       = sub () { 0 };
+    *main::SCANNER     = sub () { 0 };
+    *main::INFOLOG     = sub () { 0 };
+    *main::DEBUGLOG    = sub () { 0 };
+    *main::ISWINDOWS   = sub () { 0 };
+    *main::ISMAC       = sub () { 0 };
+    *main::PERFMON     = sub () { 0 };
+}
+
+# M5: SPOTON_CACHE_VERSION is defined in Plugin.pm (single source of truth);
+# submodules resolve it via a fully-qualified call at load time. Production
+# always compiles Plugin.pm first — provide the constant for standalone loads.
+BEGIN {
+    package Plugins::SpotOn::Plugin;
+    use constant SPOTON_CACHE_VERSION => 4;
+}
+
+# Add to @INC
+unshift @INC, $stub_dir, $project_dir;
+
+# Pre-load stubs so subsequent `require` calls inside ProtocolHandler.pm find the stubs.
+require Plugins::SpotOn::Helper;
+require Plugins::SpotOn::API::Client;
+require Plugins::SpotOn::Unified::DaemonManager;
+require Slim::Control::Request;
+
+# ============================================================
+# Load ProtocolHandler.pm
+# ============================================================
+require_ok('Plugins::SpotOn::ProtocolHandler') or BAIL_OUT("Failed to load ProtocolHandler.pm");
+
+# ============================================================
+# Mock client object — extended from t/11_track_history.t's MockClient with
+# isSynced (canDirectStream Browse/Connect branches call it directly) and an
+# explicit id() accessor for readability in per-case setup below.
+# ============================================================
+{
+    package MockClient;
+    use overload '""' => sub { ${$_[0]} };
+    sub new { my $id = $_[1] // 'player1'; bless \$id, $_[0] }
+    sub can { return 0 }
+    sub master { $_[0] }
+    sub isSynced { 0 }
+    sub id { ${$_[0]} }
+    sub playingSong { undef }
+    sub currentPlaylistUpdateTime { 1 }
+}
+
+my $prefs = Slim::Utils::Prefs::preferences('plugin.spoton');
+
+# ============================================================
+# Group A: COMPAT-02 canDirectStream proxy gate + global resolution (GH #96)
+# Each case uses a FRESH MockClient id — the Prefs stub keys per-client
+# namespaces by id and has no remove method, so reusing an id would leak
+# state between cases.
+# ============================================================
+
+subtest 'COMPAT-02: per-player proxy forces canDirectStream=0 for Browse URL' => sub {
+    my $client = MockClient->new('gateA1');
+    $prefs->client($client)->set('streamingMode', 'proxy');
+
+    my $result = Plugins::SpotOn::ProtocolHandler->canDirectStream($client, 'spoton://track:ABC123');
+    is($result, 0, 'per-player streamingMode=proxy returns 0 for Browse URL');
+};
+
+subtest 'COMPAT-02: per-player proxy forces canDirectStream=0 for Connect URL' => sub {
+    my $client = MockClient->new('gateA2');
+    $prefs->client($client)->set('streamingMode', 'proxy');
+
+    my $result = Plugins::SpotOn::ProtocolHandler->canDirectStream($client, 'spoton://connect-20260703-test');
+    is($result, 0, 'per-player streamingMode=proxy returns 0 for Connect URL');
+};
+
+subtest 'COMPAT-02: per-player direct overrides a global proxy default' => sub {
+    $prefs->set('streamingMode', 'proxy');
+    my $client = MockClient->new('gateA3');
+    $prefs->client($client)->set('streamingMode', 'direct');
+
+    my $result = Plugins::SpotOn::ProtocolHandler->canDirectStream($client, 'spoton://track:ABC123');
+    ok($result, 'per-player direct overrides a global proxy default (truthy result)');
+    like($result, qr{/track/ABC123}, 'result is the daemon HTTP URL for the requested track');
+};
+
+subtest 'COMPAT-02: per-player explicit global resolves against a global proxy default' => sub {
+    $prefs->set('streamingMode', 'proxy');
+    my $client = MockClient->new('gateA4');
+    $prefs->client($client)->set('streamingMode', 'global');
+
+    my $result = Plugins::SpotOn::ProtocolHandler->canDirectStream($client, 'spoton://track:ABC123');
+    is($result, 0, 'per-player global explicitly resolves against a global proxy default -> 0');
+};
+
+subtest 'COMPAT-02: per-player unset resolves against a global proxy default' => sub {
+    $prefs->set('streamingMode', 'proxy');
+    my $client = MockClient->new('gateA5');
+    # No per-player streamingMode pref set at all — unset behaves as 'global'
+
+    my $result = Plugins::SpotOn::ProtocolHandler->canDirectStream($client, 'spoton://track:ABC123');
+    is($result, 0, 'per-player unset resolves against a global proxy default -> 0');
+};
+
+subtest 'COMPAT-02: all-unset defaults to direct (regression — default behavior unchanged)' => sub {
+    # Explicitly clear the global default to simulate a totally fresh install
+    $prefs->set('streamingMode', undef);
+    my $client = MockClient->new('gateA6');
+
+    my $result = Plugins::SpotOn::ProtocolHandler->canDirectStream($client, 'spoton://track:ABC123');
+    ok($result, 'all prefs unset returns truthy daemon HTTP URL (default behavior unchanged)');
+    like($result, qr{/track/ABC123}, 'result contains /track/ABC123');
+};
+
+subtest 'COMPAT-02: per-player global resolves against a global direct default' => sub {
+    $prefs->set('streamingMode', 'direct');
+    my $client = MockClient->new('gateA7');
+    $prefs->client($client)->set('streamingMode', 'global');
+
+    my $result = Plugins::SpotOn::ProtocolHandler->canDirectStream($client, 'spoton://track:ABC123');
+    ok($result, 'per-player global resolves against a global direct default -> truthy');
+};
+
+# ============================================================
+# Group B: COMPAT-01 enum validation regex checks
+#
+# HONESTY NOTE (review finding): these assert a copy of the regex, not
+# Settings/Player.pm handler execution — the per-player handler is covered
+# by the grep acceptance criteria in Task 1 plus manual UAT. The GLOBAL
+# handler gets real execution coverage in t/09_settings.t.
+# ============================================================
+
+subtest 'COMPAT-01: per-player streamingMode enum regex (global|direct|proxy)' => sub {
+    my $re = qr/^(?:global|direct|proxy)$/;
+    ok('global' =~ $re, 'per-player regex accepts global');
+    ok('direct' =~ $re, 'per-player regex accepts direct');
+    ok('proxy'  =~ $re, 'per-player regex accepts proxy');
+    ok('bogus' !~ $re, 'per-player regex rejects an invalid value');
+    ok(''      !~ $re, 'per-player regex rejects an empty string');
+};
+
+subtest 'COMPAT-01: global streamingMode enum regex (direct|proxy)' => sub {
+    my $re = qr/^(?:direct|proxy)$/;
+    ok('direct' =~ $re, 'global regex accepts direct');
+    ok('proxy'  =~ $re, 'global regex accepts proxy');
+    ok('global' !~ $re, 'global regex rejects "global" (not a valid global-scope value)');
+    ok('bogus'  !~ $re, 'global regex rejects an invalid value');
+    ok(''       !~ $re, 'global regex rejects an empty string');
+};
+
+# ============================================================
+# Group C: i18n coverage — all 7 PLUGIN_SPOTON_STREAMING_MODE* keys exist
+# with exactly the 11 required locale lines before the next blank line.
+# ============================================================
+
+subtest 'i18n: PLUGIN_SPOTON_STREAMING_MODE* keys have all 11 locales' => sub {
+    my $strings_file = "$project_dir/Plugins/SpotOn/strings.txt";
+    open(my $fh, '<', $strings_file) or BAIL_OUT("Cannot read strings.txt: $!");
+    my @lines = <$fh>;
+    close($fh);
+
+    my @required_keys = qw(
+        PLUGIN_SPOTON_STREAMING_MODE
+        PLUGIN_SPOTON_STREAMING_MODE_DESC
+        PLUGIN_SPOTON_STREAMING_MODE_DIRECT
+        PLUGIN_SPOTON_STREAMING_MODE_PROXY
+        PLUGIN_SPOTON_STREAMING_MODE_USE_GLOBAL
+        PLUGIN_SPOTON_STREAMING_MODE_GLOBAL
+        PLUGIN_SPOTON_STREAMING_MODE_GLOBAL_DESC
+    );
+    my @required_locales = sort qw(CS DA DE EN ES FR IT NL NO PL SV);
+
+    for my $key (@required_keys) {
+        my $found_idx;
+        for my $i (0 .. $#lines) {
+            my $line = $lines[$i];
+            chomp $line;
+            if ($line eq $key) {
+                $found_idx = $i;
+                last;
+            }
+        }
+        ok(defined $found_idx, "i18n: $key exists as a line-anchored key header");
+        next unless defined $found_idx;
+
+        my %locales_seen;
+        my $i = $found_idx + 1;
+        while ($i <= $#lines) {
+            my $line = $lines[$i];
+            chomp $line;
+            last if $line eq '';
+            if ($line =~ /^\t([A-Z]{2})\t/) {
+                $locales_seen{$1} = 1;
+            }
+            $i++;
+        }
+        is(join(',', sort keys %locales_seen), join(',', @required_locales),
+            "i18n: $key has exactly the 11 required locale lines");
+    }
+};
+
+done_testing();


### PR DESCRIPTION
## Summary

- Per-player **Streaming Mode** preference with a global server-wide default, fixing metadata loss for third-party players like WiiM via UPnPBridge (#96)
- `canDirectStream()` proxy gate returns 0 when effective mode is `proxy`, forcing LMS to relay the stream and preserve metadata
- `getMetadataFor()` / `getIcon()` URL canonicalization maps daemon HTTP URLs to `spoton://` cache keys, eliminating cache misses from `parseDirectHeaders()`

## Details

**Settings (COMPAT-01):**
- Server Settings: global Streaming Mode default (Direct / Proxy), default Direct
- Player Settings: per-player override (Global / Direct / Proxy), default Global
- Per-player `direct` overrides global `proxy`; per-player `global` (or unset) resolves to the server default
- 7 new i18n keys across all 11 locales (CS/DA/DE/EN/ES/FR/IT/NL/NO/PL/SV)

**Proxy Gate (COMPAT-02):**
- Single top-of-function gate in `canDirectStream()` — covers both Browse and Connect URLs
- Resolves per-player mode against global default before deciding
- No interaction with `isSynced()` or `streamFormat` (orthogonal)

**URL Canonicalization (COMPAT-03):**
- `getMetadataFor()` and `getIcon()` canonicalize `http://host:PORT/track/ID` → `spoton://track:ID`
- Tolerates `?start_position=N` query string suffix (seek scenarios)
- `/stream` URLs excluded per design (Connect proxy, no track ID)

## Test plan

- [x] 455 unit tests pass (`prove t/`) — no regressions
- [x] New `t/15_streaming_mode.t` (35 assertions): proxy gate, global resolution, per-player override, i18n coverage
- [x] Extended `t/11_track_history.t`: HTTP→spoton:// canonicalization, query-string tolerance, episode URLs, /stream exclusion
- [x] Extended `t/09_settings.t`: global streamingMode handler save/validation via real handler execution
- [x] Live UAT: Browse playback verified in direct and proxy mode, pause/resume/skip in proxy mode, per-player override confirmed via LMS logs

Closes #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)