### PR TITLE
Improve SpotOn metadata handling and display titles

### DIFF
--- a/Plugins/SpotOn/Connect.pm
+++ b/Plugins/SpotOn/Connect.pm
@@ -1021,13 +1021,30 @@ sub _fetchTrackMetadata {
         my $album    = ($trackInfo->{album} || {})->{name} || '';
         my $duration = ($trackInfo->{duration_ms} || 0) / 1000;
         my $cover    = _largestImage(($trackInfo->{album} || {})->{images}) || IMG_TRACK;
+        my $logicalUrl = ($song->track && $song->track->url)
+            ? $song->track->url
+            : $song->streamUrl;
+        my $streamUrl = $song->streamUrl;
+        my $displayTitle = "$artist - $title";
 
         # Instant display update
+        # LMS/status paths usually key current_title by the logical
+        # spoton://connect-* URL, while some renderers key display metadata
+        # off the resolved stream URL. Set both keys when they differ.
+        require Slim::Music::Info;
         Slim::Music::Info::setCurrentTitle(
-            $song->streamUrl,
-            "$artist - $title",
+            $logicalUrl,
+            $displayTitle,
             $client
         );
+        if ($streamUrl && $streamUrl ne $logicalUrl) {
+            Slim::Music::Info::setCurrentTitle(
+                $streamUrl,
+                $displayTitle,
+                $client
+            );
+        }
+
 
         # Full metadata for Now Playing display
         require Plugins::SpotOn::Plugin;
@@ -1039,7 +1056,8 @@ sub _fetchTrackMetadata {
             album        => $album,
             duration     => $duration,
             cover        => $cover,
-            url          => $song->streamUrl,
+            icon         => $cover,
+            url          => $logicalUrl,
             bitrate      => $bitrate . 'k',
             originalType => $type_str,
             type         => $type_str,

--- a/Plugins/SpotOn/Plugin.pm
+++ b/Plugins/SpotOn/Plugin.pm
@@ -1022,6 +1022,9 @@ sub _trackItem {
 
     my %item = (
         name          => "$title \x{2014} $artist",    # em-dash fallback for older clients
+        title         => $title,
+        artist        => $artist,
+        album         => $album,
         line1         => $title,
         line2         => $artist . ($album ? " \x{2022} $album" : ''),
         url           => $spoton_url,
@@ -1778,7 +1781,7 @@ sub _episodeItem {
     $cache->set('spoton_meta_' . md5_hex($spoton_url), {
         title    => $title,
         artist   => $showName,
-        album    => '',
+        album    => $showName,
         duration => $duration,
         cover    => $image,
         icon     => $image,
@@ -1790,6 +1793,9 @@ sub _episodeItem {
 
     my %item = (
         name          => $title . $explicit_tag,
+        title         => $title,
+        artist        => $showName,
+        album         => $showName,
         line1         => $title . $explicit_tag,
         line2         => $line2,
         url           => $spoton_url,
@@ -2520,6 +2526,9 @@ sub _albumTrackItem {
 
     my %item = (
         name      => ($trackNum ? "$trackNum. " : '') . $title,
+        title     => $title,
+        artist    => $artists,
+        album     => $albumName || '',
         line1     => ($trackNum ? "$trackNum. " : '') . $title,
         line2     => $line2,
         url       => $spoton_url,

--- a/Plugins/SpotOn/ProtocolHandler.pm
+++ b/Plugins/SpotOn/ProtocolHandler.pm
@@ -23,6 +23,42 @@ my $CRLF  = "\x0d\x0a";
 
 # D-05: debounce — one in-flight re-fetch per URL
 our %_pendingRefetch;
+our $_applyingCurrentTitle = 0;
+
+sub _displayTitleFromMeta {
+    my ($meta) = @_;
+    return '' unless $meta && ref $meta eq 'HASH';
+    return '' unless $meta->{title};
+    return $meta->{artist}
+        ? "$meta->{artist} - $meta->{title}"
+        : $meta->{title};
+}
+
+sub _applyRuntimeMetadata {
+    my ($client, $song, $logicalUrl, $meta) = @_;
+    return unless $client;
+    return unless $logicalUrl;
+    return unless $meta && ref $meta eq 'HASH';
+
+    # Do NOT write $song->pluginData(info => ...) here.
+    # Connect.pm uses pluginData('info') to distinguish live Connect sessions
+    # from dead history entries and to guard against Connect metadata bleed.
+    if ($song && $meta->{duration}
+        && !($song->duration && $song->duration > 0)) {
+        $song->duration($meta->{duration});
+    }
+
+    return unless $meta->{title};
+    return if $_applyingCurrentTitle;
+
+    local $_applyingCurrentTitle = 1;
+    require Slim::Music::Info;
+    Slim::Music::Info::setCurrentTitle(
+        $logicalUrl,
+        _displayTitleFromMeta($meta),
+        $client
+    );
+}
 
 # Track Connect URLs translated to Browse by getNextTrack
 my %_translatedConnectUrls;
@@ -828,10 +864,16 @@ sub getMetadataFor {
 
     if ($client) {
         require Plugins::SpotOn::Plugin;
-        return { %$meta,
+        # Override type/bitrate unconditionally: they are per-player values and
+        # must not leak from another player's cached metadata.
+        my %out = (
+            %$meta,
             type    => Plugins::SpotOn::Plugin->_typeString($client, 'Browse'),
             bitrate => Plugins::SpotOn::Plugin->_bitrateForClient($client) . 'k',
-        };
+            url     => $canonical,
+        );
+        _applyRuntimeMetadata($client, $song, $canonical, \%out);
+        return \%out;
     }
 
     return $meta;
@@ -887,6 +929,9 @@ sub _buildExplodedEpisodeItem {
     my $url   = 'spoton://episode:' . $ep->{id};
     return {
         name     => $title,
+        title    => $title,
+        artist   => $show->{name} || '',
+        album    => $show->{name} || '',
         line1    => $title,
         line2    => $show->{name} || '',
         url      => $url,
@@ -922,7 +967,7 @@ sub _cacheExplodedEpisode {
     $cache->set('spoton_meta_' . md5_hex($epUrl), {
         title    => $ep->{name} || '',
         artist   => $show->{name} || '',
-        album    => '',
+        album    => $show->{name} || '',
         duration => ($ep->{duration_ms} || 0) / 1000,
         cover    => $cover,
         icon     => $cover,
@@ -1001,7 +1046,7 @@ sub _asyncRefetch {
 
         if ($episodeId) {
             $artist = ($info->{show} || {})->{name} || '';
-            $album  = '';
+            $album  = $artist;
             $cover  = _largestImage($info->{images})
                    || _largestImage(($info->{show} || {})->{images})
                    || '/html/images/cover.png';
@@ -1037,6 +1082,14 @@ sub _asyncRefetch {
             : $canonical;
 
         $cache->set('spoton_meta_' . md5_hex($cacheUrl), \%new_meta, 604800);
+
+        $new_meta{url} ||= $cacheUrl;
+        my $refetchSong;
+        if ($client && $client->can('currentSongForUrl')) {
+            $refetchSong = $client->currentSongForUrl($cacheUrl);
+        }
+        _applyRuntimeMetadata($client, $refetchSong, $cacheUrl, \%new_meta)
+            if $client;
 
         # Notify LMS to refresh NowPlaying display
         if ($client) {


### PR DESCRIPTION
Set and prefer a logical URL for display metadata (spoton://...) while also setting the resolved stream URL key so renderers that use either get correct current_title. Add icon and canonical url to Connect metadata and use a single display title variable. Expose title/artist/album fields for track, episode and album item builders so clients can access structured metadata. Introduce _displayTitleFromMeta and _applyRuntimeMetadata in ProtocolHandler to safely apply runtime metadata (duration and current title) to live clients without writing pluginData and preventing recursive updates. Ensure getMetadataFor returns client-specific type/bitrate and canonical url, and call _applyRuntimeMetadata during refetch to refresh NowPlaying display. Misc: normalize episode album to show name and guard against metadata bleed between players.