### PR TITLE
Add release year to track metadata

### DIFF
--- a/Plugins/SpotOn/Connect.pm
+++ b/Plugins/SpotOn/Connect.pm
@@ -1021,6 +1021,7 @@ sub _fetchTrackMetadata {
         my $album    = ($trackInfo->{album} || {})->{name} || '';
         my $duration = ($trackInfo->{duration_ms} || 0) / 1000;
         my $cover    = _largestImage(($trackInfo->{album} || {})->{images}) || IMG_TRACK;
+        my $year     = Plugins::SpotOn::Plugin::_releaseYear(($trackInfo->{album} || {})->{release_date});
 
         # Instant display update — set on both logical and stream URL so renderers
         # that key their display off the stream URL (e.g. UPnPBridge) also get the title
@@ -1053,6 +1054,7 @@ sub _fetchTrackMetadata {
             duration     => $duration,
             cover        => $cover,
             icon         => $cover,
+            year         => $year,
             url          => $logicalUrl,
             bitrate      => $bitrate . 'k',
             originalType => $type_str,
@@ -1073,6 +1075,7 @@ sub _fetchTrackMetadata {
                     duration   => $duration,
                     cover      => $cover,
                     icon       => $cover,
+                    year       => $year,
                     bitrate    => $bitrate . 'k',
                     type       => $type_str,
                     spotifyUri => $trackInfo->{uri},

--- a/Plugins/SpotOn/DontStopTheMusic.pm
+++ b/Plugins/SpotOn/DontStopTheMusic.pm
@@ -265,6 +265,7 @@ sub _cacheAndExtractUris {
         my $artist = join(', ', map { $_->{name} } @{ $track->{artists} || [] });
         my $images = $track->{album}{images} || [];
         my $image  = @$images ? (sort { ($b->{width}||0) <=> ($a->{width}||0) } @$images)[0]->{url} : '';
+        my $year   = Plugins::SpotOn::Plugin::_releaseYear(($track->{album} || {})->{release_date});
 
         # D-02: 7-day TTL (604800s) so DSTM tracks survive in history for a week
         # WR-01: include artist/album IDs so trackInfoMenu can build navigation items.
@@ -276,6 +277,7 @@ sub _cacheAndExtractUris {
             duration => ($track->{duration_ms} || 0) / 1000,
             cover    => $image,
             icon     => $image,
+            year     => $year,
             bitrate  => Plugins::SpotOn::Plugin->_bitrateForClient(undef) . 'k',
             type     => $type_str,
             %trackIds,

--- a/Plugins/SpotOn/Plugin.pm
+++ b/Plugins/SpotOn/Plugin.pm
@@ -75,6 +75,7 @@ sub _flushDeferredMeta {
                 duration => $p->{duration},
                 cover    => $p->{cover},
                 icon     => $p->{icon},
+                year     => $p->{year} // '',
                 bitrate  => $bitrate,
                 type     => $type,
                 %trackIds,
@@ -608,6 +609,13 @@ sub trackInfoMenu {
     my @items;
 
     if ($type eq 'track') {
+        if ($meta->{year}) {
+            push @items, {
+                name  => $meta->{year},
+                type  => 'text',
+                label => 'YEAR',
+            };
+        }
         if ($meta->{artistId}) {
             push @items, {
                 name        => cstring($client, 'PLUGIN_SPOTON_ARTIST_VIEW'),
@@ -902,6 +910,15 @@ sub _largestImage {
     return $largest->{url} || '';
 }
 
+# _releaseYear($release_date)
+# Extracts the 4-digit release year from a Spotify release_date string (YYYY, YYYY-MM, or YYYY-MM-DD).
+# Returns '' when the input is undef or does not begin with four digits.
+sub _releaseYear {
+    my ($release_date) = @_;
+    return '' unless $release_date && $release_date =~ /^(\d{4})/;
+    return $1;
+}
+
 # Regex pattern for Spotify-generated personal mix playlists (D-06).
 # Uses \s+ instead of literal spaces for whitespace variants.
 # Both call sites (_madeForYouFeed and _userPlaylistsFeed)
@@ -933,6 +950,7 @@ sub _trackItem {
     my $album    = $track->{album}{name} // '';
     my $image    = _largestImage($track->{album}{images});
     my $duration = ($track->{duration_ms} || 0) / 1000;
+    my $year     = _releaseYear($track->{album}{release_date});
 
     # D-07: Build context navigation items for artist and album drill-down.
     # Only add links when IDs are available (simplified track objects may lack album).
@@ -951,6 +969,13 @@ sub _trackItem {
             name  => $album,
             type  => 'text',
             label => 'ALBUM',
+        };
+    }
+    if ($year) {
+        push @contextItems, {
+            name  => $year,
+            type  => 'text',
+            label => 'YEAR',
         };
     }
     if ($track->{artists} && @{ $track->{artists} } && $track->{artists}[0]{id}) {
@@ -1002,6 +1027,7 @@ sub _trackItem {
             duration => $duration,
             cover    => $image,
             icon     => $image,
+            year     => $year,
             track    => $track,    # kept for _extractTrackIds (encode_json deferred to flush)
             client   => $client,
         };
@@ -1014,6 +1040,7 @@ sub _trackItem {
             duration  => $duration,
             cover     => $image,
             icon      => $image,
+            year      => $year,
             bitrate   => __PACKAGE__->_bitrateForClient($client) . 'k',
             type      => __PACKAGE__->_typeString($client, 'Browse'),
             %trackIds,
@@ -1060,7 +1087,7 @@ sub _albumItem {
     return {
         name          => $album->{name} // '',
         url           => \&_albumFeed,
-        passthrough   => [{ albumId => $album->{id}, albumImages => $album->{images}, albumArtist => $firstArtist, albumName => $album->{name} }],
+        passthrough   => [{ albumId => $album->{id}, albumImages => $album->{images}, albumArtist => $firstArtist, albumName => $album->{name}, albumReleaseDate => $releaseDate }],
         image         => _largestImage($album->{images}),
         line2         => $line2,
         favorites_url => $album_spoton,
@@ -2315,10 +2342,11 @@ sub _artistAlbumsFeed {
 sub _albumFeed {
     my ($client, $callback, $args, $passthrough) = @_;
 
-    my $albumId      = $passthrough->{albumId}      // '';
-    my $albumImages  = $passthrough->{albumImages};    # undef on first load
-    my $albumArtist  = $passthrough->{albumArtist}  // '';
-    my $albumName    = $passthrough->{albumName}    // '';    # WR-01: carried for metadata cache
+    my $albumId          = $passthrough->{albumId}          // '';
+    my $albumImages      = $passthrough->{albumImages};    # undef on first load
+    my $albumArtist      = $passthrough->{albumArtist}      // '';
+    my $albumName        = $passthrough->{albumName}        // '';    # WR-01: carried for metadata cache
+    my $albumReleaseDate = $passthrough->{albumReleaseDate} // '';    # carried for release year in track metadata
 
     my $offset = $args->{index}    || 0;
     my $qty    = $args->{quantity} || 200;
@@ -2341,12 +2369,13 @@ sub _albumFeed {
             my $total       = ($album->{tracks} && $album->{tracks}{total}) ? $album->{tracks}{total} : 0;
             my $seedTracks  = ($album->{tracks} && $album->{tracks}{items}) ? $album->{tracks}{items} : [];
             my $albumNm     = $album->{name} // '';
+            my $albumRd     = $album->{release_date} // '';
 
             if ($total <= scalar(@{$seedTracks})) {
                 # All tracks already in getAlbum response — no further API calls needed
                 # FIX-01: defer metadata cache writes.
                 my @deferredMeta;
-                my @items = map { _albumTrackItem($client, $_, $images, $artist0, $albumNm, { defer_cache => \@deferredMeta }) } @{$seedTracks};
+                my @items = map { _albumTrackItem($client, $_, $images, $artist0, $albumNm, { defer_cache => \@deferredMeta, albumReleaseDate => $albumRd }) } @{$seedTracks};
                 if (!@items) {
                     push @items, { name => cstring($client, 'PLUGIN_SPOTON_NO_RESULTS'), type => 'textarea' };
                 }
@@ -2372,7 +2401,7 @@ sub _albumFeed {
                         undef $fetchPage;
                         # FIX-01: defer metadata cache writes.
                         my @deferredMeta;
-                        my @items = map { _albumTrackItem($client, $_, $images, $artist0, $albumNm, { defer_cache => \@deferredMeta }) } @accumulated;
+                        my @items = map { _albumTrackItem($client, $_, $images, $artist0, $albumNm, { defer_cache => \@deferredMeta, albumReleaseDate => $albumRd }) } @accumulated;
                         if (!@items) {
                             push @items, { name => cstring($client, 'PLUGIN_SPOTON_NO_RESULTS'), type => 'textarea' };
                         }
@@ -2390,7 +2419,7 @@ sub _albumFeed {
                         undef $fetchPage;
                         # FIX-01: defer metadata cache writes.
                         my @deferredMeta;
-                        my @items = map { _albumTrackItem($client, $_, $images, $artist0, $albumNm, { defer_cache => \@deferredMeta }) } @accumulated;
+                        my @items = map { _albumTrackItem($client, $_, $images, $artist0, $albumNm, { defer_cache => \@deferredMeta, albumReleaseDate => $albumRd }) } @accumulated;
                         if (!@items) {
                             push @items, { name => cstring($client, 'PLUGIN_SPOTON_NO_RESULTS'), type => 'textarea' };
                         }
@@ -2426,7 +2455,7 @@ sub _albumFeed {
             my $total    = ($album->{tracks} && $album->{tracks}{total}) ? $album->{tracks}{total} : 0;
             my $tracks   = ($album->{tracks} && $album->{tracks}{items}) ? $album->{tracks}{items} : [];
 
-            my @items = map { _albumTrackItem($client, $_, $images, $artist0, $album->{name}) } @{$tracks};
+            my @items = map { _albumTrackItem($client, $_, $images, $artist0, $album->{name}, { albumReleaseDate => $album->{release_date} // '' }) } @{$tracks};
 
             if (!@items) {
                 push @items, { name => cstring($client, 'PLUGIN_SPOTON_NO_RESULTS'), type => 'textarea' };
@@ -2446,7 +2475,7 @@ sub _albumFeed {
                 return;
             }
 
-            my @items = map { _albumTrackItem($client, $_, $albumImages, $albumArtist, $albumName) } @{ $data->{items} || [] };
+            my @items = map { _albumTrackItem($client, $_, $albumImages, $albumArtist, $albumName, { albumReleaseDate => $albumReleaseDate }) } @{ $data->{items} || [] };
 
             if (!@items) {
                 push @items, { name => cstring($client, 'PLUGIN_SPOTON_NO_RESULTS'), type => 'textarea' };
@@ -2472,12 +2501,38 @@ sub _albumTrackItem {
     my $artists   = join(', ', map { $_->{name} } @{ $track->{artists} || [] });
     my $image     = _largestImage($albumImages);
     my $duration  = ($track->{duration_ms} || 0) / 1000;
+    my $year      = (ref $opts eq 'HASH' && $opts->{albumReleaseDate})
+                        ? _releaseYear($opts->{albumReleaseDate})
+                        : '';
 
     # Show featuring artists in line2 only when they differ from album's primary artist.
     my $line2 = ($artists && $artists ne ($albumArtist // '')) ? $artists : '';
 
     # Context navigation: artist view (no album view — already in album context).
+    # UX-05: label-bearing text items MUST come first so XMLBrowser populates $details
+    # and enables Play/Queue/Favorites buttons in the Default skin info view.
     my @contextItems;
+    if ($artists) {
+        push @contextItems, {
+            name  => $artists,
+            type  => 'text',
+            label => 'ARTIST',
+        };
+    }
+    if ($albumName) {
+        push @contextItems, {
+            name  => $albumName,
+            type  => 'text',
+            label => 'ALBUM',
+        };
+    }
+    if ($year) {
+        push @contextItems, {
+            name  => $year,
+            type  => 'text',
+            label => 'YEAR',
+        };
+    }
     if ($track->{artists} && @{ $track->{artists} } && $track->{artists}[0]{id}) {
         push @contextItems, {
             name        => cstring($client, 'PLUGIN_SPOTON_ARTIST_VIEW'),
@@ -2508,6 +2563,7 @@ sub _albumTrackItem {
             duration => $duration,
             cover    => $image,
             icon     => $image,
+            year     => $year,
             track    => $track,
             client   => $client,
         };
@@ -2520,6 +2576,7 @@ sub _albumTrackItem {
             duration => $duration,
             cover    => $image,
             icon     => $image,
+            year     => $year,
             bitrate  => __PACKAGE__->_bitrateForClient($client) . 'k',
             type     => __PACKAGE__->_typeString($client, 'Browse'),
             %trackIds,

--- a/Plugins/SpotOn/ProtocolHandler.pm
+++ b/Plugins/SpotOn/ProtocolHandler.pm
@@ -545,10 +545,11 @@ sub explodePlaylist {
                 return;
             }
 
-            my $albumName  = $album->{name} || '';
-            my $albumCover = _largestImage($album->{images}) || '/html/images/cover.png';
-            my $tracksData = $album->{tracks} || {};
-            my $total      = $tracksData->{total} || 0;
+            my $albumName        = $album->{name} || '';
+            my $albumCover       = _largestImage($album->{images}) || '/html/images/cover.png';
+            my $albumReleaseDate = $album->{release_date} // '';
+            my $tracksData       = $album->{tracks} || {};
+            my $total            = $tracksData->{total} || 0;
 
             # H5: pagination offsets and completion checks must count RAW page
             # items. @allItems is filtered (tracks without an id are skipped),
@@ -560,7 +561,7 @@ sub explodePlaylist {
                 next unless $track && $track->{id};
                 my $item = _buildExplodedTrackItem($track, $albumName, $albumCover);
                 push @allItems, $item;
-                _cacheExplodedTrack($item->{url}, $track, $albumName, $albumCover, $albumId);
+                _cacheExplodedTrack($item->{url}, $track, $albumName, $albumCover, $albumId, $albumReleaseDate);
             }
 
             if ($fetched >= $total) {
@@ -589,7 +590,7 @@ sub explodePlaylist {
                         next unless $track && $track->{id};
                         my $item = _buildExplodedTrackItem($track, $albumName, $albumCover);
                         push @allItems, $item;
-                        _cacheExplodedTrack($item->{url}, $track, $albumName, $albumCover, $albumId);
+                        _cacheExplodedTrack($item->{url}, $track, $albumName, $albumCover, $albumId, $albumReleaseDate);
                     }
                     if ($fetched < $total && @{ $data->{items} }) {
                         $fetchPage->($fetched);
@@ -880,6 +881,9 @@ sub getMetadataFor {
                     : $meta->{title};
                 $track->title($display);
             }
+            if ($meta->{year} && $track->can('year') && !$track->year) {
+                $track->year($meta->{year});
+            }
         }
     }
 
@@ -958,10 +962,13 @@ sub _buildExplodedEpisodeItem {
 }
 
 sub _cacheExplodedTrack {
-    my ($trackUrl, $track, $albumName, $albumCover, $albumId) = @_;
+    my ($trackUrl, $track, $albumName, $albumCover, $albumId, $albumReleaseDate) = @_;
     require Plugins::SpotOn::Plugin;
     my %ids = Plugins::SpotOn::Plugin::_extractTrackIds($track);
     $ids{albumId} = $albumId if defined $albumId;    # explicit album context overrides
+    my $year = Plugins::SpotOn::Plugin::_releaseYear(
+        $albumReleaseDate // ($track->{album} || {})->{release_date}
+    );
     $cache->set('spoton_meta_' . md5_hex($trackUrl), {
         title     => $track->{name} || '',
         artist    => join(', ', map { $_->{name} } @{ $track->{artists} || [] }),
@@ -969,6 +976,7 @@ sub _cacheExplodedTrack {
         duration  => ($track->{duration_ms} || 0) / 1000,
         cover     => $albumCover || '/html/images/cover.png',
         icon      => $albumCover || '/html/images/cover.png',
+        year      => $year,
         %ids,
     }, 3600);
 }
@@ -1057,7 +1065,7 @@ sub _asyncRefetch {
 
         my $title    = $info->{name};
         my $duration = ($info->{duration_ms} || 0) / 1000;
-        my ($artist, $album, $cover);
+        my ($artist, $album, $cover, $year);
 
         if ($episodeId) {
             $artist = ($info->{show} || {})->{name} || '';
@@ -1065,11 +1073,14 @@ sub _asyncRefetch {
             $cover  = _largestImage($info->{images})
                    || _largestImage(($info->{show} || {})->{images})
                    || '/html/images/cover.png';
+            $year   = '';
         } else {
             $artist = join(', ', map { $_->{name} } @{ $info->{artists} || [] });
             $album  = ($info->{album} || {})->{name} || '';
             $cover  = _largestImage(($info->{album} || {})->{images})
                    || '/html/images/cover.png';
+            require Plugins::SpotOn::Plugin;
+            $year   = Plugins::SpotOn::Plugin::_releaseYear(($info->{album} || {})->{release_date});
         }
 
         my %new_meta = (
@@ -1079,6 +1090,7 @@ sub _asyncRefetch {
             duration => $duration,
             cover    => $cover,
             icon     => $cover,
+            year     => $year,
         );
 
         if ($episodeId) {

--- a/t/11_track_history.t
+++ b/t/11_track_history.t
@@ -580,7 +580,7 @@ subtest 'Async re-fetch populates cache and fires newmetadata' => sub {
     $Plugins::SpotOn::API::Client::mock_track = {
         name       => 'Async Track',
         artists    => [{ name => 'Async Artist' }],
-        album      => { name => 'Async Album', images => [{ url => 'https://example.com/img.jpg', width => 640 }] },
+        album      => { name => 'Async Album', images => [{ url => 'https://example.com/img.jpg', width => 640 }], release_date => '2021-03-19' },
         duration_ms => 210000,
     };
 
@@ -600,6 +600,7 @@ subtest 'Async re-fetch populates cache and fires newmetadata' => sub {
     ok(defined $cached, 'Cache populated after async re-fetch callback');
     is($cached->{title}, 'Async Track', 'Cached title matches API response');
     is($cached->{artist}, 'Async Artist', 'Cached artist matches API response');
+    is($cached->{year}, '2021', 'Cached year extracted from album.release_date');
     cmp_ok($Slim::Control::Request::notify_count, '>=', 1, 'notifyFromArray fired after re-fetch');
 
     # Clean up mock

--- a/t/14_context_menu.t
+++ b/t/14_context_menu.t
@@ -396,9 +396,9 @@ ok( !defined(&Plugins::SpotOn::ProtocolHandler::trackInfoURL),
 }
 
 # ============================================================
-# Test 4: trackInfoMenu returns 4-item arrayref for a track URL
-# with metadata containing artistId and albumId.
-# Items: ARTIST_VIEW, ALBUM_VIEW, MANAGE_LIKE, ADD_TO_PLAYLIST
+# Test 4: trackInfoMenu returns 5-item arrayref for a track URL
+# with metadata containing artistId, albumId, and year.
+# Items: YEAR (text), ARTIST_VIEW, ALBUM_VIEW, MANAGE_LIKE, ADD_TO_PLAYLIST
 # ============================================================
 {
     my $client  = MockClient->new('player-test4');
@@ -416,6 +416,7 @@ ok( !defined(&Plugins::SpotOn::ProtocolHandler::trackInfoURL),
         artistId => 'artistABC',
         albumId  => 'albumDEF',
         duration => 240,
+        year     => '2021',
     });
 
     my $result = Plugins::SpotOn::Plugin::trackInfoMenu(
@@ -425,10 +426,11 @@ ok( !defined(&Plugins::SpotOn::ProtocolHandler::trackInfoURL),
     ok( defined $result && ref($result) eq 'ARRAY',
         'CTX-04: trackInfoMenu returns arrayref for track URL with artistId+albumId' );
 
-    is( scalar @$result, 4,
-        'CTX-04: trackInfoMenu returns exactly 4 items for track with artistId and albumId' );
+    is( scalar @$result, 5,
+        'CTX-04: trackInfoMenu returns exactly 5 items for track with artistId, albumId, and year' );
 
-    my @names = map { $_->{name} } @$result;
+    my @names  = map { $_->{name}  } @$result;
+    my @labels = map { $_->{label} // '' } @$result;
     ok( (grep { $_ eq 'PLUGIN_SPOTON_ARTIST_VIEW' } @names),
         'CTX-04: item list includes PLUGIN_SPOTON_ARTIST_VIEW' );
     ok( (grep { $_ eq 'PLUGIN_SPOTON_ALBUM_VIEW' } @names),
@@ -437,6 +439,13 @@ ok( !defined(&Plugins::SpotOn::ProtocolHandler::trackInfoURL),
         'CTX-04: item list includes PLUGIN_SPOTON_MANAGE_LIKE' );
     ok( (grep { $_ eq 'PLUGIN_SPOTON_ADD_TO_PLAYLIST' } @names),
         'CTX-04: item list includes PLUGIN_SPOTON_ADD_TO_PLAYLIST' );
+    ok( (grep { $_ eq '2021' } @names),
+        'CTX-04: item list includes year value 2021' );
+    ok( (grep { $_ eq 'YEAR' } @labels),
+        'CTX-04: year item has label YEAR' );
+    is( $result->[0]{name},  '2021', 'CTX-04: year item is first in list' );
+    is( $result->[0]{label}, 'YEAR', 'CTX-04: first item label is YEAR' );
+    is( $result->[0]{type},  'text', 'CTX-04: year item type is text' );
 }
 
 # ============================================================


### PR DESCRIPTION
Propagates album release year through SpotOn track metadata paths (browse items, connect updates, exploded album tracks, deferred cache flushes, and async refetch) using a shared `_releaseYear` helper. The year is now exposed in track context menus as a `YEAR` text item and written to cached metadata so players can populate track year fields. Tests were updated to cover year extraction and the expanded context menu output.