### PR TITLE
Add search history feature

### DIFF
--- a/Plugins/SpotOn/Plugin.pm
+++ b/Plugins/SpotOn/Plugin.pm
@@ -22,6 +22,7 @@ use File::Spec::Functions qw(catdir catfile);
 use constant KILL_PROCESS_INTERVAL => 3600;    # Hourly orphaned-process cleanup (STR-10)
 use constant SPOTON_CACHE_VERSION  => 4;       # Bump to flush all SpotOn cache entries (D-01/D-02)
 use constant FLUSH_BATCH           => 50;      # Items per event-loop tick in _flushDeferredMeta (FIX-01)
+use constant MAX_RECENT_SEARCHES   => 50;      # Maximum stored search history entries
 
 my $prefs = preferences('plugin.spoton');
 my $cache = Slim::Utils::Cache->new('spoton', SPOTON_CACHE_VERSION);
@@ -117,6 +118,7 @@ sub initPlugin {
         cacheSchemaVersion   => 0,     # D-02: migration marker — triggers cache clear on version bump
         diagnosticMode       => 0,     # #3: diagnostic logging toggle, default off
         streamingMode        => 'direct', # COMPAT-01: global streaming mode default (direct|proxy); per-player override lives in same-name client pref (GH #96)
+        spoton_recent_search => [],    # ordered list of recent search strings (oldest first)
     });
 
     # D-02: cacheSchemaVersion guard — log when cache namespace version was bumped
@@ -254,6 +256,16 @@ sub initPlugin {
         after  => 'lastplayed',
         func   => \&_infoUrl,
     ) );
+
+    # Search history CLI — used by itemActions context menu on recent search entries
+    #                                                           |requires Client
+    #                                                           |  |is a Query
+    #                                                           |  |  |has Tags
+    #                                                           |  |  |  |Function to call
+    #                                                           C  Q  T  F
+    Slim::Control::Request::addDispatch(['spoton', 'recentsearches'],
+                                                                [0, 0, 1, \&_recentSearchesCLI]
+    );
 }
 
 sub shutdownPlugin {
@@ -514,9 +526,9 @@ sub handleFeed {
         };
         push @items, {
             name  => cstring($client, 'PLUGIN_SPOTON_SEARCH'),
-            url   => \&_searchFeed,
+            url   => \&_searchPageFeed,
             image => 'plugins/SpotOn/html/images/search.png',
-            type  => 'search',
+            type  => 'link',
         };
         push @items, {
             name  => cstring($client, 'PLUGIN_SPOTON_LIBRARY'),
@@ -2487,6 +2499,162 @@ sub _multiTypeSearch {
     }
 }
 
+# Search History Helpers
+#
+# _hasRecentSearches()
+# Returns true if there is at least one stored recent search.
+sub _hasRecentSearches {
+    return scalar @{ $prefs->get('spoton_recent_search') || [] };
+}
+
+# _addRecentSearch($query)
+# Prepend $query to the recent-search list, removing duplicates and capping at
+# MAX_RECENT_SEARCHES entries (oldest are dropped).  List is stored oldest-first
+# so unshift at display time yields newest-first order.
+sub _addRecentSearch {
+    my ($query) = @_;
+    return unless defined $query && $query ne '';
+
+    my $list = $prefs->get('spoton_recent_search') || [];
+
+    # remove duplicates (case-sensitive, same as Spotty)
+    $list = [ grep { $_ ne $query } @$list ];
+
+    push @$list, $query;
+
+    # trim to MAX_RECENT_SEARCHES (keep newest)
+    $list = [ @{$list}[ (-1 * MAX_RECENT_SEARCHES)..-1 ] ] if scalar @$list > MAX_RECENT_SEARCHES;
+
+    $prefs->set('spoton_recent_search', $list);
+}
+
+# _searchPageFeed($client, $callback, $args)
+# The dedicated Search page.  When there are saved searches it shows:
+#   • a `search` input item at the top (New Search)
+#   • history entries newest-first, each with a context-menu action to delete it
+# When there is no history at all it falls back to a plain `search` item so
+# the user still gets a working search box.
+sub _searchPageFeed {
+    my ($client, $callback, $args) = @_;
+
+    # If called directly with a search query (e.g. from a type=search item),
+    # forward straight to _searchFeed instead of showing the search page.
+    if (($args->{search} // '') ne '') {
+        _searchFeed($client, $callback, $args);
+        return;
+    }
+
+    my $list = $prefs->get('spoton_recent_search') || [];
+
+    my @items;
+
+    # Always put the live search input at the top of the dedicated page.
+    # No image key — keeps the row compact regardless of cover-size setting,
+    # matching Spotty's search-page layout.
+    push @items, {
+        name  => cstring($client, 'PLUGIN_SPOTON_NEW_SEARCH'),
+        type  => 'search',
+        url   => \&_searchFeed,
+    };
+
+    # History is stored oldest-first; display newest-first below the search box.
+    # $i counts from the newest entry so deleteMenu indices match the stored list.
+    # No image key — history entries must not show the magnifying-glass icon.
+    my $last = $#$list;
+    for my $i ( reverse 0 .. $last ) {
+        push @items, {
+            name        => $list->[$i],
+            type        => 'link',
+            url         => \&_searchFromHistoryFeed,
+            passthrough => [{ query => $list->[$i] }],
+            itemActions => {
+                info => {
+                    command     => ['spoton', 'recentsearches'],
+                    fixedParams => { deleteMenu => $i },
+                },
+            },
+        };
+    }
+
+    $callback->({ items => \@items });
+}
+
+# _recentSearchesCLI($request)
+# CLI handler for `spoton recentsearches` — used by the itemActions context menu
+# on history entries.  Supports three modes:
+#   deleteMenu=N  — return a confirmation sub-menu (delete single / clear all)
+#   delete=N      — remove entry at index N
+#   deleteAll=1   — wipe the entire history
+sub _recentSearchesCLI {
+    my $request = shift;
+    my $client  = $request->client;
+
+    if ($request->isNotCommand([['spoton'], ['recentsearches']])) {
+        $request->setStatusBadDispatch();
+        return;
+    }
+
+    my $list = $prefs->get('spoton_recent_search') || [];
+
+    if (defined $request->getParam('deleteMenu')) {
+        my $del = $request->getParam('deleteMenu') + 0;
+
+        if ($del >= scalar @$list) {
+            $request->setStatusBadParams();
+            return;
+        }
+
+        my $items = [
+            {
+                text => cstring($client, 'DELETE') . cstring($client, 'COLON') . ' "' . ($list->[$del] // '') . '"',
+                actions => {
+                    go => {
+                        player => 0,
+                        cmd    => ['spoton', 'recentsearches'],
+                        params => { delete => $del },
+                    },
+                },
+                nextWindow => 'parent',
+            },
+            {
+                text => cstring($client, 'PLUGIN_SPOTON_CLEAR_SEARCH_HISTORY'),
+                actions => {
+                    go => {
+                        player => 0,
+                        cmd    => ['spoton', 'recentsearches'],
+                        params => { deleteAll => 1 },
+                    },
+                },
+                nextWindow => 'grandParent',
+            },
+        ];
+
+        $request->addResult('offset', 0);
+        $request->addResult('count', scalar @$items);
+        $request->addResult('item_loop', $items);
+    }
+    elsif ($request->getParam('deleteAll')) {
+        $prefs->set('spoton_recent_search', []);
+    }
+    elsif (defined $request->getParam('delete')) {
+        my $del = $request->getParam('delete') + 0;
+        splice(@$list, $del, 1);
+        $prefs->set('spoton_recent_search', $list);
+    }
+
+    $request->setStatusDone;
+}
+
+# _searchFromHistoryFeed($client, $callback, $args, $passthrough)
+# Thin shim that replays a recent search without re-adding it to history.
+# Called when the user taps a history entry from _searchPageFeed.
+sub _searchFromHistoryFeed {
+    my ($client, $callback, $args, $passthrough) = @_;
+    $args->{search} = $passthrough->{query} // '';
+    $args->{_fromHistory} = 1;
+    _searchFeed($client, $callback, $args);
+}
+
 # _searchFeed($client, $callback, $args)
 # Entry point for the Search type item. LMS passes the search query in $args->{search}.
 # Per D-10: Top Result shown prominently above category sections.
@@ -2581,6 +2749,9 @@ sub _searchFeed {
 
         if (!@items) {
             push @items, { name => cstring($client, 'PLUGIN_SPOTON_NO_RESULTS'), type => 'textarea' };
+        } else {
+            # Store successful search in history (skip if called from history replay)
+            _addRecentSearch($query) unless $args->{_fromHistory};
         }
 
         $callback->({ items => \@items });

--- a/Plugins/SpotOn/strings.txt
+++ b/Plugins/SpotOn/strings.txt
@@ -2936,3 +2936,29 @@ PLUGIN_SPOTON_SYNC_GROUP_SUFFIX
 	PL	(Grupa)
 	SV	(Grupp)
 
+
+PLUGIN_SPOTON_NEW_SEARCH
+	CS	Nové hledání
+	DA	Ny søgning
+	DE	Neue Suche
+	EN	New Search
+	ES	Nueva búsqueda
+	FR	Nouvelle recherche
+	IT	Nuova ricerca
+	NL	Nieuwe zoekopdracht
+	NO	Nytt søk
+	PL	Nowe wyszukiwanie
+	SV	Ny sökning
+
+PLUGIN_SPOTON_CLEAR_SEARCH_HISTORY
+	CS	Vymazat historii hledání
+	DA	Ryd søgehistorik
+	DE	Suchverlauf löschen
+	EN	Clear Search History
+	ES	Borrar historial de búsqueda
+	FR	Effacer l'historique des recherches
+	IT	Cancella la cronologia delle ricerche
+	NL	Zoekgeschiedenis wissen
+	NO	Tøm søkehistorikk
+	PL	Wyczyść historię wyszukiwania
+	SV	Rensa sökhistorik


### PR DESCRIPTION
### Added
- **Recent search history (last 50 entries, newest-first)** — the dedicated search page now shows a **New Search** input followed by previous queries, each with a context menu to delete a single entry or clear all history. History is stored, deduplicated, and capped at 50 entries. New strings `PLUGIN_SPOTON_NEW_SEARCH` and `PLUGIN_SPOTON_CLEAR_SEARCH_HISTORY` added in 11 languages.

### Fixed
- **Classic Skin split the SpotOn main menu into separate sections** — the top-level Search entry used `type => 'search'`, which Classic Skin interprets as a section break. It now uses `type => 'link'` and always navigates to the dedicated search page first, matching Spotty's two-step UX pattern.

- **Search query entered from the main menu produced no results** — `_searchPageFeed` ignored `$args->{search}` entirely. It now forwards to `_searchFeed` immediately when a query is already present.

- **Search history entries appeared above the search input and delete indices were wrong** — the history loop used `unshift` while incrementing `$i` forward, placing history above the input box and misaligning `deleteMenu` indices with stored entries. Fixed by iterating `reverse 0 .. $last` with `push` so newest entries appear below the search box and `$i` directly indexes the stored list.

- **Search page layout differed from Spotty depending on cover-size setting** — the "New Search" input item and history entries carried an `image` key, causing LMS to apply the large-cover row height when "große Plattenhüllen" was active. Removed image keys from both, matching Spotty's compact, image-free search-page layout.
- **Magnifying-glass icon appeared in front of every saved search entry** — same root cause; removing `image` from history entries eliminates the icon.